### PR TITLE
Add "GraphQL over HTTP" specification to agenda

### DIFF
--- a/agendas/2017-10-27.md
+++ b/agendas/2017-10-27.md
@@ -57,6 +57,7 @@ Martijn Walraven    | Apollo        | San Francisco, CA
 1. Discuss interest in and possible scope of defining a more structured format for errors
 1. Discuss next steps for ["Standardizing unique IDs in the spec/tooling"](https://github.com/facebook/graphql/pull/232)
 1. Update on community projects around schema stitching
+1. "GraphQL over HTTP" specification (20m)
 1. Discuss upcoming meeting schedule (5m)
 
 ## Agenda and Attendee guidelines


### PR DESCRIPTION
GraphQL spec doesn't document transport layer and I think it's great. It allows a lot of flexibility and experimentation.

It's great that we have a standard for query and responses but you should be able to send those in a standardized manner. We faced this issue while working on a few GraphQL proxy tools at APIs.guru and we think it may be a limiting factor for the growth of GraphQL tooling.

My proposal is to create separate "GraphQL over HTTP" specification based on [express-graphql](https://github.com/graphql/express-graphql) and just document existing practices as the first step.