### PR TITLE
Add "Status of Scalar serialize as built-in scalar type RFC" to agenda

### DIFF
--- a/agendas/2017-10-27.md
+++ b/agendas/2017-10-27.md
@@ -60,6 +60,7 @@ Michael Hunger      | Neo4j         | Dresden, Germany
 1. Discuss next steps for ["Standardizing unique IDs in the spec/tooling"](https://github.com/facebook/graphql/pull/232)
 1. Update on community projects around schema stitching
 1. "GraphQL over HTTP" specification (20m)
+1. Status of [Scalar serialize as built-in scalar type](https://github.com/facebook/graphql/pull/326) RFC (10m)
 1. Discuss upcoming meeting schedule (5m)
 
 ## Agenda and Attendee guidelines


### PR DESCRIPTION
It looks like there are no blockers for https://github.com/facebook/graphql/pull/326 and https://github.com/graphql/graphql-js/pull/914 to be merged. What are the next steps for this proposal?
