### PR TITLE
Add status of IDL specification to agenda

### DIFF
--- a/agendas/2017-10-27.md
+++ b/agendas/2017-10-27.md
@@ -60,6 +60,7 @@ Michael Hunger      | Neo4j         | Dresden, Germany
 1. Discuss next steps for ["Standardizing unique IDs in the spec/tooling"](https://github.com/facebook/graphql/pull/232)
 1. Update on community projects around schema stitching
 1. "GraphQL over HTTP" specification (20m)
+1. Discuss status of IDL specification(10m)
 1. Discuss upcoming meeting schedule (5m)
 
 ## Agenda and Attendee guidelines


### PR DESCRIPTION
Many community projects rely on the IDL, however, it is not currently included as part of the GraphQL spec. Would like to discuss the state of plans for adding IDL to spec.