### PR TITLE
Add ‘best practices’ specs to agenda and myself to attendees.

### DIFF
--- a/agendas/2018-02-01.md
+++ b/agendas/2018-02-01.md
@@ -24,7 +24,7 @@ receive logistics. Plan to arrive at least 10 minutes before the meeting begins.
 ## Attendees
 
 Name                 | Organization  | Location
--------------------- | ------------- | ------------------
+-------------------- | ------------- | ----------------------
 Lee Byron            | Facebook      | Menlo Park, CA
 Ivan Goncharov       | APIs.guru     | Lviv, Ukraine
 Johannes Schickling  | Graphcool     | San Francisco, CA
@@ -33,6 +33,7 @@ Marc Giroux          | GitHub        | Montreal, Canada
 Oleg Ilyenko         | Sangria       | Berlin, Germany
 Kim Brandwijk        | Supergraphql  | The Netherlands
 Mike Marcacci        | Boltline      | San Diego, CA
+Eloy Durán           | Artsy         | Amsterdam, Netherlands
 
 <small>\*: willing to take notes (eg. <em>Joe Montana*</em>)</small>
 
@@ -47,6 +48,7 @@ Mike Marcacci        | Boltline      | San Diego, CA
 1. Discuss exposing schema metadata (30m)
 1. Discuss errors (30m)
 1. Discuss interface hierarchies (30m)
+1. Discuss moving connection/global ID specs from Relay into best practices repo (15m)
 
 ## Agenda and Attendee guidelines
 


### PR DESCRIPTION
Not _entirely_ sure this is the right avenue for it, but proposing just in case.

In short, I’d like to propose detaching the [Connections](https://facebook.github.io/relay/graphql/connections.htm) and [Global Object Identification](https://facebook.github.io/relay/graphql/objectidentification.htm) specifications from the ‘Relay’ brand and move them into a ‘best practices’ specifications repo that’s closer to the GraphQL brand, because my experience is that people avoid these for the wrong reasons.

[Here’s](https://github.com/facebook/graphql/issues/131#issuecomment-347206352) an older comment of my proposal that has seen some upvotes.