### PR TITLE
Add Alan to attendees and live queries to agenda

### DIFF
--- a/agendas/2018-02-01.md
+++ b/agendas/2018-02-01.md
@@ -33,6 +33,7 @@ Marc Giroux          | GitHub        | Montreal, Canada
 Oleg Ilyenko         | Sangria       | Berlin, Germany
 Kim Brandwijk        | Supergraphql  | The Netherlands
 Mike Marcacci        | Boltline      | San Diego, CA
+Alan Johnson *       | Artsy         | New York, NY
 
 <small>\*: willing to take notes (eg. <em>Joe Montana*</em>)</small>
 
@@ -47,6 +48,7 @@ Mike Marcacci        | Boltline      | San Diego, CA
 1. Discuss exposing schema metadata (30m)
 1. Discuss errors (30m)
 1. Discuss interface hierarchies (30m)
+1. Discuss subscriptions for live queries (15m)
 
 ## Agenda and Attendee guidelines
 


### PR DESCRIPTION
I'm interested in attending in-person. But I assumed location to be where I work. Not sure!

Also, didn't want to block too much time for discussion of live queries. I think 15 mins should be sufficient to share the findings of initial research, the next steps, and get some feedback.

I'm happy to take notes on another agenda section.