### PR TITLE
Update 2018-03-22 attendance

### DIFF
--- a/agendas/2018-03-22.md
+++ b/agendas/2018-03-22.md
@@ -24,6 +24,7 @@ Andreas Marek        | graphql-java/Atlassian | Sydney, Australia
 Brad Baker           | graphql-java/Atlassian | Sydney, Australia
 Johannes Schickling  | Graphcool     | Menlo Park, CA
 Evans Hauser         | Apollo        | San Francisco, CA
+Tony Ghita           | graphql-go/Twitch | San Francisco, CA
 
 <small>\*: willing to take notes (eg. <em>Joe Montana*</em>)</small>
 


### PR DESCRIPTION
Adds Tony to the participants list. 

We discussed status of the graphql-go library and desire for a canonical set of tests coupled to the specification to encourage ecosystem parity between implementations.