### PR TITLE
Add myself and Mat Byrne

### DIFF
--- a/agendas/2018-11-08.md
+++ b/agendas/2018-11-08.md
@@ -19,6 +19,8 @@ Name                 | Organization  | Location
 -------------------- | ------------- | ----------------------
 Lee Byron            | Robinhood     | Menlo Park, CA
 Michael Staib*       | ChilliCream   | Zurich, Switzerland
+Adam Scarr           | 99designs     | Melbourne, Australia (in SF)
+Mathew Byrne         | 99designs     | Melbourne, Australia (in SF)
 
 <small>\*: willing to take notes (eg. <em>Joe Montana*</em>)</small>
 
@@ -28,6 +30,7 @@ Michael Staib*       | ChilliCream   | Zurich, Switzerland
 1. Introduction of attendees
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
+1. graphql-cats adoption issues (5m)
 
 ## Agenda and Attendee guidelines
 


### PR DESCRIPTION
Adding [graphql-cats](https://github.com/graphql-cats/graphql-cats) support to [gqlgen](https://github.com/99designs/gqlgen) is going to be tricky, and still isn't supported by [graphql-js](https://github.com/graphql/graphql-js/issues/1404). What are the blockers and how can we make this easier?