### PR TITLE
Add physical location for Apollo HQ

### DIFF
--- a/agendas/2018-11-08.md
+++ b/agendas/2018-11-08.md
@@ -13,6 +13,12 @@ This session is timed to align with the [GraphQL Summit](https://summit.graphql.
   - 7:00AM - 10:00AM AEST (UTC+11) (Nov 9th) (Sydney)
   - 9:00PM - 12:00AM CEST (UTC+1) (Berlin)
 
+## Physical Locations
+
+**Apollo HQ**
+  * [140 10th St, San Francisco, CA 94103](https://goo.gl/maps/S7tzxCFpbcu)
+  * 2nd floor, Andromeda conference room
+
 ## Attendees
 
 Name                 | Organization  | Location


### PR DESCRIPTION
Apollo is happy to host the GraphQL WG and host any of its attendees who might be in San Francisco.  We have a large conference room with video conferencing equipment reserved that can be used by remote attendees.

Ref: https://github.com/graphql/graphql-wg/pull/115#issuecomment-435749665

cc @leebyron @IvanGoncharov