### PR TITLE
Add upcoming schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,31 @@
 GraphQL Working Group
 =====================
 
-GraphQL WG (Working Group) is a semi-regular virtual meeting of maintainers of
+GraphQL WG (Working Group) is a monthly virtual meeting of maintainers of
 commonly used GraphQL libraries and tools and significant contributors to the
-GraphQL community.
+GraphQL community, operated by the GraphQL Foundation.
 
-The agenda of these meetings may contain anything from technical discussions
-about GraphQL specification and tools to planning of upcoming GraphQL events or
-coordination of educational efforts.
+The GraphQL WG's primary purpose is to discuss and agree upon
+proposed additions to the [GraphQL Specification](https://github.com/graphql/graphql-spec). Additionally, the group may discuss and collaborate on other
+relevant technical topics concerning core GraphQL projects.
 
-This repository holds agendas and details for upcoming meetings as well as any
-meeting notes from prior meetings.
+Anyone in the public GraphQL community may attend a GraphQL WG meeting, provided
+they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
 
-All meetings occur via a group video conference, however participating company
+This repository holds **agendas** and **notes** for all meetings past and
+upcoming. Anyone may edit an upcoming event's agenda to *attend* or *propose a topic*.
+
+All meetings occur via video conference, however participating company
 offices are welcome to host guests.
+
+Meetings are typically scheduled for the first Thursday of each month at 9:00am
+Pacific US time. Check the [`agendas/`](./agendas) for the exact date and time
+of upcoming meetings.
 
 ## Joining a meeting?
 
 To request participation in an upcoming meeting, please send a pull request by
-editing the relevant meeting in [`agendas/`](./agendas).
+editing the relevant [meeting agenda](./agendas).
 
 ## Want to help us keep up?
 

--- a/agendas/2019-05-02.md
+++ b/agendas/2019-05-02.md
@@ -1,0 +1,44 @@
+# GraphQL WG – May 2019
+
+The GraphQL Working Group meets monthly to discuss proposed additions to the
+[GraphQL Specification](https://github.com/graphql/graphql-spec) and other
+relevant topics to core GraphQL projects. Anyone in the public GraphQL
+community may attend, provided they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [May 2nd 2019 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=5&day=2&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+
+<small>*NOTE:* Meeting date and time may change up to a week before the meeting.
+Please check the agenda the week of the meeting to confirm.</small>
+
+
+## Agenda and Attendee Guidelines
+
+*To attend this meeting or propose a topic*, edit this page and add your name
+to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+- Each attendee (or attendee's organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+- Read the [participation guidelines](../README.md#participation-guidelines).
+- To cover everything, discussion may be time-constrained per topic.
+- Topics that require less discussion should be covered first.
+- To respect meeting size, attendees should be relevant to the agenda.
+
+
+## Attendees
+
+Name                 | Organization       | Location
+-------------------- | ------------------ | ----------------------
+Lee Byron            | GraphQL Foundation | Menlo Park, CA
+<ADD YOUR NAME HERE> | <COMPANY / ORG>    | <WHERE YOU ARE>
+
+<small>\*: willing to take notes (eg. Joe Montana\*)</small>
+
+
+## Agenda
+
+1. Opening of the meeting
+1. Introduction of attendees
+1. Review agenda (5m)
+1. Determine volunteers for note taking (5m)
+1. <ADD YOUR AGENDA ITEM ABOVE HERE>

--- a/agendas/2019-06-06.md
+++ b/agendas/2019-06-06.md
@@ -1,0 +1,44 @@
+# GraphQL WG – June 2019
+
+The GraphQL Working Group meets monthly to discuss proposed additions to the
+[GraphQL Specification](https://github.com/graphql/graphql-spec) and other
+relevant topics to core GraphQL projects. Anyone in the public GraphQL
+community may attend, provided they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [June 6th 2019 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=6&day=6&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+
+<small>*NOTE:* Meeting date and time may change up to a week before the meeting.
+Please check the agenda the week of the meeting to confirm.</small>
+
+
+## Agenda and Attendee Guidelines
+
+*To attend this meeting or propose a topic*, edit this page and add your name
+to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+- Each attendee (or attendee's organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+- Read the [participation guidelines](../README.md#participation-guidelines).
+- To cover everything, discussion may be time-constrained per topic.
+- Topics that require less discussion should be covered first.
+- To respect meeting size, attendees should be relevant to the agenda.
+
+
+## Attendees
+
+Name                 | Organization       | Location
+-------------------- | ------------------ | ----------------------
+Lee Byron            | GraphQL Foundation | Menlo Park, CA
+<ADD YOUR NAME HERE> | <COMPANY / ORG>    | <WHERE YOU ARE>
+
+<small>\*: willing to take notes (eg. Joe Montana\*)</small>
+
+
+## Agenda
+
+1. Opening of the meeting
+1. Introduction of attendees
+1. Review agenda (5m)
+1. Determine volunteers for note taking (5m)
+1. <ADD YOUR AGENDA ITEM ABOVE HERE>

--- a/agendas/2019-07-03.md
+++ b/agendas/2019-07-03.md
@@ -1,0 +1,44 @@
+# GraphQL WG – July 2019
+
+The GraphQL Working Group meets monthly to discuss proposed additions to the
+[GraphQL Specification](https://github.com/graphql/graphql-spec) and other
+relevant topics to core GraphQL projects. Anyone in the public GraphQL
+community may attend, provided they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [July 3rd 2019 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=7&day=3&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+
+<small>*NOTE:* Meeting date and time may change up to a week before the meeting.
+Please check the agenda the week of the meeting to confirm.</small>
+
+
+## Agenda and Attendee Guidelines
+
+*To attend this meeting or propose a topic*, edit this page and add your name
+to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+- Each attendee (or attendee's organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+- Read the [participation guidelines](../README.md#participation-guidelines).
+- To cover everything, discussion may be time-constrained per topic.
+- Topics that require less discussion should be covered first.
+- To respect meeting size, attendees should be relevant to the agenda.
+
+
+## Attendees
+
+Name                 | Organization       | Location
+-------------------- | ------------------ | ----------------------
+Lee Byron            | GraphQL Foundation | Menlo Park, CA
+<ADD YOUR NAME HERE> | <COMPANY / ORG>    | <WHERE YOU ARE>
+
+<small>\*: willing to take notes (eg. Joe Montana\*)</small>
+
+
+## Agenda
+
+1. Opening of the meeting
+1. Introduction of attendees
+1. Review agenda (5m)
+1. Determine volunteers for note taking (5m)
+1. <ADD YOUR AGENDA ITEM ABOVE HERE>

--- a/agendas/2019-08-01.md
+++ b/agendas/2019-08-01.md
@@ -1,0 +1,44 @@
+# GraphQL WG – August 2019
+
+The GraphQL Working Group meets monthly to discuss proposed additions to the
+[GraphQL Specification](https://github.com/graphql/graphql-spec) and other
+relevant topics to core GraphQL projects. Anyone in the public GraphQL
+community may attend, provided they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [August 1st 2019 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=8&day=1&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+
+<small>*NOTE:* Meeting date and time may change up to a week before the meeting.
+Please check the agenda the week of the meeting to confirm.</small>
+
+
+## Agenda and Attendee Guidelines
+
+*To attend this meeting or propose a topic*, edit this page and add your name
+to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+- Each attendee (or attendee's organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+- Read the [participation guidelines](../README.md#participation-guidelines).
+- To cover everything, discussion may be time-constrained per topic.
+- Topics that require less discussion should be covered first.
+- To respect meeting size, attendees should be relevant to the agenda.
+
+
+## Attendees
+
+Name                 | Organization       | Location
+-------------------- | ------------------ | ----------------------
+Lee Byron            | GraphQL Foundation | Menlo Park, CA
+<ADD YOUR NAME HERE> | <COMPANY / ORG>    | <WHERE YOU ARE>
+
+<small>\*: willing to take notes (eg. Joe Montana\*)</small>
+
+
+## Agenda
+
+1. Opening of the meeting
+1. Introduction of attendees
+1. Review agenda (5m)
+1. Determine volunteers for note taking (5m)
+1. <ADD YOUR AGENDA ITEM ABOVE HERE>

--- a/agendas/2019-09-12.md
+++ b/agendas/2019-09-12.md
@@ -1,0 +1,44 @@
+# GraphQL WG – September 2019
+
+The GraphQL Working Group meets monthly to discuss proposed additions to the
+[GraphQL Specification](https://github.com/graphql/graphql-spec) and other
+relevant topics to core GraphQL projects. Anyone in the public GraphQL
+community may attend, provided they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [September 12th 2019 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=9&day=12&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+
+<small>*NOTE:* Meeting date and time may change up to a week before the meeting.
+Please check the agenda the week of the meeting to confirm.</small>
+
+
+## Agenda and Attendee Guidelines
+
+*To attend this meeting or propose a topic*, edit this page and add your name
+to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+- Each attendee (or attendee's organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+- Read the [participation guidelines](../README.md#participation-guidelines).
+- To cover everything, discussion may be time-constrained per topic.
+- Topics that require less discussion should be covered first.
+- To respect meeting size, attendees should be relevant to the agenda.
+
+
+## Attendees
+
+Name                 | Organization       | Location
+-------------------- | ------------------ | ----------------------
+Lee Byron            | GraphQL Foundation | Menlo Park, CA
+<ADD YOUR NAME HERE> | <COMPANY / ORG>    | <WHERE YOU ARE>
+
+<small>\*: willing to take notes (eg. Joe Montana\*)</small>
+
+
+## Agenda
+
+1. Opening of the meeting
+1. Introduction of attendees
+1. Review agenda (5m)
+1. Determine volunteers for note taking (5m)
+1. <ADD YOUR AGENDA ITEM ABOVE HERE>

--- a/agendas/2019-10-10.md
+++ b/agendas/2019-10-10.md
@@ -1,0 +1,44 @@
+# GraphQL WG – October 2019
+
+The GraphQL Working Group meets monthly to discuss proposed additions to the
+[GraphQL Specification](https://github.com/graphql/graphql-spec) and other
+relevant topics to core GraphQL projects. Anyone in the public GraphQL
+community may attend, provided they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [October 10th 2019 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=10&day=10&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+
+<small>*NOTE:* Meeting date and time may change up to a week before the meeting.
+Please check the agenda the week of the meeting to confirm.</small>
+
+
+## Agenda and Attendee Guidelines
+
+*To attend this meeting or propose a topic*, edit this page and add your name
+to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+- Each attendee (or attendee's organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+- Read the [participation guidelines](../README.md#participation-guidelines).
+- To cover everything, discussion may be time-constrained per topic.
+- Topics that require less discussion should be covered first.
+- To respect meeting size, attendees should be relevant to the agenda.
+
+
+## Attendees
+
+Name                 | Organization       | Location
+-------------------- | ------------------ | ----------------------
+Lee Byron            | GraphQL Foundation | Menlo Park, CA
+<ADD YOUR NAME HERE> | <COMPANY / ORG>    | <WHERE YOU ARE>
+
+<small>\*: willing to take notes (eg. Joe Montana\*)</small>
+
+
+## Agenda
+
+1. Opening of the meeting
+1. Introduction of attendees
+1. Review agenda (5m)
+1. Determine volunteers for note taking (5m)
+1. <ADD YOUR AGENDA ITEM ABOVE HERE>

--- a/agendas/2019-11-07.md
+++ b/agendas/2019-11-07.md
@@ -1,0 +1,44 @@
+# GraphQL WG – November 2019
+
+The GraphQL Working Group meets monthly to discuss proposed additions to the
+[GraphQL Specification](https://github.com/graphql/graphql-spec) and other
+relevant topics to core GraphQL projects. Anyone in the public GraphQL
+community may attend, provided they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [November 7th 2019 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=11&day=7&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+
+<small>*NOTE:* Meeting date and time may change up to a week before the meeting.
+Please check the agenda the week of the meeting to confirm.</small>
+
+
+## Agenda and Attendee Guidelines
+
+*To attend this meeting or propose a topic*, edit this page and add your name
+to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+- Each attendee (or attendee's organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+- Read the [participation guidelines](../README.md#participation-guidelines).
+- To cover everything, discussion may be time-constrained per topic.
+- Topics that require less discussion should be covered first.
+- To respect meeting size, attendees should be relevant to the agenda.
+
+
+## Attendees
+
+Name                 | Organization       | Location
+-------------------- | ------------------ | ----------------------
+Lee Byron            | GraphQL Foundation | Menlo Park, CA
+<ADD YOUR NAME HERE> | <COMPANY / ORG>    | <WHERE YOU ARE>
+
+<small>\*: willing to take notes (eg. Joe Montana\*)</small>
+
+
+## Agenda
+
+1. Opening of the meeting
+1. Introduction of attendees
+1. Review agenda (5m)
+1. Determine volunteers for note taking (5m)
+1. <ADD YOUR AGENDA ITEM ABOVE HERE>

--- a/agendas/2019-12-05.md
+++ b/agendas/2019-12-05.md
@@ -1,0 +1,44 @@
+# GraphQL WG – December 2019
+
+The GraphQL Working Group meets monthly to discuss proposed additions to the
+[GraphQL Specification](https://github.com/graphql/graphql-spec) and other
+relevant topics to core GraphQL projects. Anyone in the public GraphQL
+community may attend, provided they first sign the [Specification Membership Agreement](https://github.com/graphql/foundation) or belong to an organization who has signed.
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [December 5th 2019 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=12&day=5&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+
+<small>*NOTE:* Meeting date and time may change up to a week before the meeting.
+Please check the agenda the week of the meeting to confirm.</small>
+
+
+## Agenda and Attendee Guidelines
+
+*To attend this meeting or propose a topic*, edit this page and add your name
+to the list of attendees below along with your organization and location. Add any agenda item you wish to discuss, please include relevant links.
+
+- Each attendee (or attendee's organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+- Read the [participation guidelines](../README.md#participation-guidelines).
+- To cover everything, discussion may be time-constrained per topic.
+- Topics that require less discussion should be covered first.
+- To respect meeting size, attendees should be relevant to the agenda.
+
+
+## Attendees
+
+Name                 | Organization       | Location
+-------------------- | ------------------ | ----------------------
+Lee Byron            | GraphQL Foundation | Menlo Park, CA
+<ADD YOUR NAME HERE> | <COMPANY / ORG>    | <WHERE YOU ARE>
+
+<small>\*: willing to take notes (eg. Joe Montana\*)</small>
+
+
+## Agenda
+
+1. Opening of the meeting
+1. Introduction of attendees
+1. Review agenda (5m)
+1. Determine volunteers for note taking (5m)
+1. <ADD YOUR AGENDA ITEM ABOVE HERE>


### PR DESCRIPTION
Now that the GraphQL Foundation is formed, I'm bringing my attention back to the Working Group meetings. I know there hasn't been much motion on the spec or working group for the last 6 months while we've been figuring things out. I really appreciate everyone's patience and know we have a lot to cover and catch up on.

I'm proposing here a monthly cadence: the first Thursday of each month. Because our biggest growing community cohort is in europe and the middle or east coast US, I'm also proposing moving the times back to 9am pacific. I understand that this is very much not an ideal time for asia/pacific/austrialia. Frankly, it's near impossible to pick a time that doesn't overlap late evening hours for someone in the community. We may adjust times for some future meetings to balance the pain. I'm open to feedback.

This also updates the readme and guidelines in each agenda to include links to https://github.com/graphql/foundation with references to the legal document you must sign to attend. *Please sign this before the next WG meeting*, I know most regular attendees have done so already.