### PR TITLE
Add myself to May. Add TCQ.app agenda item

### DIFF
--- a/agendas/2019-05-02.md
+++ b/agendas/2019-05-02.md
@@ -30,7 +30,7 @@ to the list of attendees below along with your organization and location. Add an
 Name                 | Organization       | Location
 -------------------- | ------------------ | ----------------------
 Lee Byron            | GraphQL Foundation | Menlo Park, CA
-*ADD YOUR NAME HERE* | *COMPANY / ORG*    | *WHERE YOU ARE*
+Steve Faulkner | Microsoft    | Philadelphia, PA
 
 <small>\*: willing to take notes (eg. Joe Montana\*)</small>
 
@@ -41,4 +41,4 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 1. Introduction of attendees
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
-1. *ADD YOUR AGENDA ITEM ABOVE HERE*
+1. Discuss using https://tcq.app/ (15m)


### PR DESCRIPTION
Meetings with remote participants can be really hard to manage, especially when discussing controversial topics. The README participation guidelines talk about some of these challenges. TC39 and Ember core team both use an app called [TCQ](https://tcq.app/) to facilitate meetings very similar to ours. I'm not proposing we use it yet, just discuss the idea of using it for future meetings. I'll give a demo.