### PR TITLE
Add Tim, Input Unions to 2019-05-02 agenda

### DIFF
--- a/agendas/2019-05-02.md
+++ b/agendas/2019-05-02.md
@@ -36,6 +36,7 @@ Orta Therox          | Individual Contrib | New York, NY
 Robert Zhu           | Amazon             | Boston, MA
 Andi Marek           | GraphQL Java/Atlassian | Sydney
 Steve Faulkner       | Microsoft          | Philadelphia, PA
+Tim Griesser         | Cypress.io         | Brooklyn, NY
 *ADD YOUR NAME HERE* | *COMPANY / ORG*    | *WHERE YOU ARE*
 
 <small>\*: willing to take notes (eg. Joe Montana\*)</small>
@@ -50,4 +51,5 @@ Steve Faulkner       | Microsoft          | Philadelphia, PA
 1. Demo / Discuss using https://tcq.app/ (Steve, 15m)
 1. OffsetDateTime Scalar (Andi, 15min)
 1. Scope out the GraphiQL Future / WG (Orta, 20m)
+1. Input Unions RFC (Tim, 30m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*


### PR DESCRIPTION
Added input union RFC to the agenda. Hopefully @binaryseed and @acao will be able to join as they've been dong most of the research work around this topic lately.