### PR TITLE
Add Benjie and GraphiQL WG update to 2019-06-06 meeting

### DIFF
--- a/agendas/2019-06-06.md
+++ b/agendas/2019-06-06.md
@@ -52,6 +52,6 @@ James Baxley         | Apollo             | Greenville, SC
 1. Introduction of attendees
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
-1. GraphiQL WG update (15m)
+1. GraphiQL WG update (Benjie) (15m)
 1. Dynamic variable declaration [proposal](https://github.com/graphql/graphql-spec/issues/583) (30m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-06-06.md
+++ b/agendas/2019-06-06.md
@@ -33,6 +33,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 Tanay Pratap         | Microsoft          | Bengaluru, India
 Evan Huus            | Shopify            | Ottawa, Canada
 Luke Korth           | Braintree          | Columbus, OH
+Benjie Gillam        | PostGraphile       | Southampton, UK
 *ADD YOUR NAME HERE* | *COMPANY / ORG*    | *WHERE YOU ARE*
 
 <small>\*: willing to take notes (eg. Joe Montana\*)</small>
@@ -44,4 +45,5 @@ Luke Korth           | Braintree          | Columbus, OH
 1. Introduction of attendees
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
+1. GraphiQL WG update (15m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*


### PR DESCRIPTION
Sub-agenda:

- Status update (hopefully from @acao, who has been doing an incredible job moving us forward)
- GraphiQL monorepo license: can we move from BSD+Patents for codemirror to MIT?
- Facebook CLA: will this be moving to a GraphQL Foundation CLA? Do we even need a CLA any more?
- Would be nice to know the status of the "keys to the kingdom" transfer, and maybe an ETA on when we can publish things to npm again