### PR TITLE
Add agenda item to review previous meeting's action items

### DIFF
--- a/agendas/2019-06-06.md
+++ b/agendas/2019-06-06.md
@@ -33,6 +33,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 Tanay Pratap         | Microsoft          | Bengaluru, India
 Evan Huus            | Shopify            | Ottawa, Canada
 Luke Korth           | Braintree          | Columbus, OH
+Bruno Scheufler\*    | GraphCMS           | Berlin, DE
 *ADD YOUR NAME HERE* | *COMPANY / ORG*    | *WHERE YOU ARE*
 
 <small>\*: willing to take notes (eg. Joe Montana\*)</small>

--- a/agendas/2019-07-03.md
+++ b/agendas/2019-07-03.md
@@ -39,7 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
-1. Review [previous meeting's action items](../notes/2019-06-06.md) and check progress on those
+1. Review [previous meeting's action items](../notes/2019-06-06.md#action-items) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-07-03.md
+++ b/agendas/2019-07-03.md
@@ -39,6 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
+1. Review [previous meeting's action items](../notes/2019-06-06.md) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-08-01.md
+++ b/agendas/2019-08-01.md
@@ -39,6 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
+1. Review [previous meeting's action items](../notes/2019-07-03.md) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-08-01.md
+++ b/agendas/2019-08-01.md
@@ -39,7 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
-1. Review [previous meeting's action items](../notes/2019-07-03.md) and check progress on those
+1. Review [previous meeting's action items](../notes/2019-07-03.md#action-items) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-09-12.md
+++ b/agendas/2019-09-12.md
@@ -39,7 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
-1. Review [previous meeting's action items](../notes/2019-08-01.md) and check progress on those
+1. Review [previous meeting's action items](../notes/2019-08-01.md#action-items) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-09-12.md
+++ b/agendas/2019-09-12.md
@@ -39,6 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
+1. Review [previous meeting's action items](../notes/2019-08-01.md) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-10-10.md
+++ b/agendas/2019-10-10.md
@@ -39,6 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
+1. Review [previous meeting's action items](../notes/2019-09-12.md) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-10-10.md
+++ b/agendas/2019-10-10.md
@@ -39,7 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
-1. Review [previous meeting's action items](../notes/2019-09-12.md) and check progress on those
+1. Review [previous meeting's action items](../notes/2019-09-12.md#action-items) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-11-07.md
+++ b/agendas/2019-11-07.md
@@ -39,6 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
+1. Review [previous meeting's action items](../notes/2019-10-10.md) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-11-07.md
+++ b/agendas/2019-11-07.md
@@ -39,7 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
-1. Review [previous meeting's action items](../notes/2019-10-10.md) and check progress on those
+1. Review [previous meeting's action items](../notes/2019-10-10.md#action-items) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-12-05.md
+++ b/agendas/2019-12-05.md
@@ -39,7 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
-1. Review [previous meeting's action items](../notes/2019-11-07.md) and check progress on those
+1. Review [previous meeting's action items](../notes/2019-11-07.md#action-items) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*

--- a/agendas/2019-12-05.md
+++ b/agendas/2019-12-05.md
@@ -39,6 +39,7 @@ Lee Byron            | GraphQL Foundation | Menlo Park, CA
 
 1. Opening of the meeting
 1. Introduction of attendees
+1. Review [previous meeting's action items](../notes/2019-11-07.md) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*


### PR DESCRIPTION
The idea of this addition was that it might be a good idea to check on the previous meeting's action items and their respective progress during every meeting so there are no unhandled roadblocks for moving ahead 🚀 