### PR TITLE
Update notes with GitHub action item links

### DIFF
--- a/notes/2019-07-03.md
+++ b/notes/2019-07-03.md
@@ -7,13 +7,13 @@
 ## Action Items
 
 * GraphQL.org Website Planning / ([@tanaypratap][])
-  * [@tanaypratap][]: Schedule 10-15m meeting to discuss where graphql.org is today and brainstorm action items
-  * Unclaimed: Create Q&A on most important details (contents, etc.)
-  * [@leebyron][]: Write up vision for code page
+  * [@tanaypratap][]: Schedule 10-15m meeting to discuss where graphql.org is today and brainstorm action items ([#208](https://github.com/graphql/graphql-wg/issues/208))
+  * Unclaimed: Create Q&A on most important details (contents, etc.) ([#210](https://github.com/graphql/graphql-wg/issues/210))
+  * [@leebyron][]: Write up vision for code page ([#209](https://github.com/graphql/graphql-wg/issues/209))
 * Acceptance Criteria for Editorial Changes / ([@IvanGoncharov][])
-  * [@IvanGoncharov][]: Check maintainers of repository
+  * [@IvanGoncharov][]: Check maintainers of repository ([#211](https://github.com/graphql/graphql-wg/issues/211))
 * DateTime RFC / ([@andimarek][])
-  * Unclaimed: RFC for introspection field for spec information
+  * Unclaimed: RFC for introspection field for spec information ([#212](https://github.com/graphql/graphql-wg/issues/212))
 
 ## Notes
 


### PR DESCRIPTION
This PR updates the action items in the 2019-07-03 notes to link to corresponding GitHub Issues, as discussed during the WG meeting.