### PR TITLE
Add GitHub issue template for meeting action items

### DIFF
--- a/.github/ISSUE_TEMPLATE/action-item.md
+++ b/.github/ISSUE_TEMPLATE/action-item.md
@@ -1,0 +1,16 @@
+---
+name: Meeting Action Item
+about: Template for action items recommended during GraphQL Working Group meetings.
+labels: 'Action item :clapper:'
+
+---
+
+<!-- description -->
+
+- assignee(s): <!-- @mention, @mention -->
+- source: <!-- link to meeting notes -->
+
+---
+
+_Note: Action Item issues are reviewed and closed during Working Group
+meetings._


### PR DESCRIPTION
This commit adds a GitHub issue template for actions items recommended during GraphQL Working Group meetings.

cc/ @IvanGoncharov 