### PR TITLE
Add discussion on object identity

### DIFF
--- a/agendas/2019-07-03.md
+++ b/agendas/2019-07-03.md
@@ -61,4 +61,5 @@ Ivan Goncharov       | Individual Contrib | Lviv, Ukraine
 1. Interface Inheritance RFC (Maracci, 15m, [RFC](https://github.com/graphql/graphql-spec/pull/373), [Implementation](https://github.com/graphql/graphql-js/pull/1218))
 1. DateTime RFC (Andi, 20m)
 1. Spec editorial change criteria & plan (Ivan, 10m)
+1. Object Identity and fetchability (Matt, 10m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*


### PR DESCRIPTION
Facebook is starting to create a notion of object identity encoded and enforced in the schema. I can discuss why, but we aren't out of experimenting phase, so aren't yet ready to create a spec RFC. Right now, the concept is more of a "plug in" to the existing spec,  that clients like Relay can depend on, rather than requiring any language changes.