### PR TITLE
Add  Object Identity to discussion

### DIFF
--- a/agendas/2019-09-12.md
+++ b/agendas/2019-09-12.md
@@ -67,4 +67,5 @@ Evan Huus            | Shopify            | Ottawa, Canada
 1. Discuss status of interface implementation by interfaces (Mike, 10m) [PR](https://github.com/graphql/graphql-js/pull/2084) [RFC](https://github.com/graphql/graphql-spec/pull/373)
 1. Discuss policy for breaking changes to typescript definitions (Mike, 10m)
 1. Input Union (Vince, 15m)
+1. Object Identity and fetchability (Matt, 10m)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*


### PR DESCRIPTION
Facebook is starting to create a notion of object identity encoded and enforced in the schema. I can discuss why, but we aren't out of experimenting phase, so aren't yet ready to create a spec RFC. Right now, the concept is more of a "plug in" to the existing spec, that clients like Relay can depend on, rather than requiring any language changes.