### PR TITLE
Clarify "Input Union" Agenda item

### DIFF
--- a/agendas/2019-10-10.md
+++ b/agendas/2019-10-10.md
@@ -50,5 +50,5 @@ Wojciech Trocki      | Red Hat/IBM         | Dublin, Ireland
 1. Review [previous meeting's action items](../notes/2019-09-12.md#action-items) and check progress on those
 1. Review agenda (5m)
 1. Determine volunteers for note taking (5m)
-1. [Input Union](https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md)
+1. Review [Input Union RFC](https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md) and discuss the next steps (30m, Vince)
 1. *ADD YOUR AGENDA ITEM ABOVE HERE*


### PR DESCRIPTION
I think we now have enough content in the RFC document to review it on WG so we can be sure that everyone on board even if they missed GitHub emails.
So I expanded "Input Union" Agenda item and also added some missing details (length and name of champion). 
@binaryseed What do you think and can you please review proposed changes?