### PR TITLE
Add repeatable directives to agenda

### DIFF
--- a/agendas/2019-10-10.md
+++ b/agendas/2019-10-10.md
@@ -66,6 +66,7 @@ Tanay Pratap         | Microsoft           | Bengaluru, India
 1. Disallow non-breakable chains of circular references in Input Objects (Benedikt, 3m) [RFC](https://github.com/graphql/graphql-spec/pull/445)
 1. Lexer lookaheads stage 3 approval (Lee, 10m) [RFC 1](https://github.com/graphql/graphql-spec/pull/599) [RFC 2](https://github.com/graphql/graphql-spec/pull/601)
 1. Spec cut date discussion (#261)
+1. Repeatable directives (10m) [RFC](https://github.com/graphql/graphql-spec/pull/472)
 1. Review [Input Union RFC](https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md) and discuss the next steps (30m, Vince)
 1. Empty composite types (Victor, 10m) [RFC](https://github.com/graphql/graphql-spec/pull/606)
 1. Review design for the code page for [graphql.org](https://github.com/graphql/graphql.github.io/issues/768) (5m)


### PR DESCRIPTION
The RFC where this change originated from has been around for over a year.

`repeatable` directives have actually been implemented in the reference implementation and are a non-breaking addition that enables use cases that are currently blocked.