### PR TITLE
Add Victor and #631 to agenda

### DIFF
--- a/agendas/2019-12-05.md
+++ b/agendas/2019-12-05.md
@@ -25,11 +25,11 @@ agenda, edit this file.*
 | Name                     | Organization / Project   | Location
 | ------------------------ | ------------------------ | ------------------------
 | Lee Byron                | GraphQL Foundation       | San Francisco, CA, US
+| Victor Andrée            | Advinans                 | Stockholm, Sweden
 | Michael Staib            | ChilliCream              | Zurich, Switzerland
 | Rafael Staib             | ChilliCream              | Zurich, Switzerland
 | Pascal Senn              | ChilliCream              | Zurich, Switzerland
 | Evan Huus                | Shopify                  | Ottawa, ON, CA
-| Victor Andrée            | Advinans                 | Stockholm, Sweden
 | *ADD YOUR NAME ABOVE TO ATTEND*
 
 
@@ -61,7 +61,7 @@ Example agenda item:
    - https://github.com/graphql/graphql-spec/pull/649
    - Compatibility concerns reserving a new directive name?
    - Ready for draft / stage 2?
-1. Make root query operation type optional (10m, Victor)
+1. Make root query operation type optional (15m, Victor)
    - PR: https://github.com/graphql/graphql-spec/pull/631
    - Just solve Query use case for empty objects (https://github.com/graphql/graphql-spec/pull/606)
 1. *ADD YOUR AGENDA ABOVE*

--- a/agendas/2019-12-05.md
+++ b/agendas/2019-12-05.md
@@ -29,6 +29,7 @@ agenda, edit this file.*
 | Rafael Staib             | ChilliCream              | Zurich, Switzerland
 | Pascal Senn              | ChilliCream              | Zurich, Switzerland
 | Evan Huus                | Shopify                  | Ottawa, ON, CA
+| Victor Andrée            | Advinans                 | Stockholm, Sweden
 | *ADD YOUR NAME ABOVE TO ATTEND*
 
 
@@ -60,4 +61,7 @@ Example agenda item:
    - https://github.com/graphql/graphql-spec/pull/649
    - Compatibility concerns reserving a new directive name?
    - Ready for draft / stage 2?
+1. Make root query operation type optional (10m, Victor)
+   - PR: https://github.com/graphql/graphql-spec/pull/631
+   - Just solve Query use case for empty objects (https://github.com/graphql/graphql-spec/pull/606)
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
I've revised my original proposal in response to feedback from October WG meeting. The most straightforward thing is to support an empty Query type (to still enable introspection), see https://github.com/graphql/graphql-spec/pull/631

Regrettably, I couldn't attend the November meeting.