### PR TITLE
Fix February 2020 agenda heading

### DIFF
--- a/agendas/2020-02-06.md
+++ b/agendas/2020-02-06.md
@@ -1,4 +1,4 @@
-# GraphQL WG – January 2020
+# GraphQL WG – February 2020
 
 The GraphQL Working Group meets monthly to discuss proposed additions to the
 [GraphQL Specification](https://github.com/graphql/graphql-spec) and other


### PR DESCRIPTION
Something I noticed when checking out the agenda. It still says "January" for the "February" agenda.