### PR TITLE
Add Matt Farmer to 2020-02-06 agenda

### DIFF
--- a/agendas/2020-02-06.md
+++ b/agendas/2020-02-06.md
@@ -25,6 +25,7 @@ agenda, edit this file.*
 | Name                     | Organization / Project   | Location
 | ------------------------ | ------------------------ | ------------------------
 | Lee Byron                | GraphQL Foundation       | San Francisco, CA, US
+| Matt Farmer              | Individual Contrib       | Oakland, CA, US
 | *ADD YOUR NAME ABOVE TO ATTEND*
 
 
@@ -51,4 +52,12 @@ Example agenda item:
 1. Review agenda (2m, Lee)
 1. Review [previous meeting's action items](../notes/2019-12-05.md#action-items) (5m, Lee)
    - [Currently open action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22)
+1. Custom Scalar Specification URIs Update (10m, Matt Farmer)
+   - Waiting for `graphql-js` `15.0.0` to be cut.  Scheduled to be included in `15.1.0` which would be released a week or two later.  [Relevant Discussion](https://github.com/graphql/graphql-js/pull/2276#discussion_r367909160).
+   - Seeking validation on how to handle use-case where a scalar is extended multiple times, which results in the directive being included in the `typeExtensionsMap` multiple times.  Currently taking the last element.
+       - [Test Case](https://github.com/graphql/graphql-js/pull/2276/files#r364908343)
+       - [Relevant Source code](https://github.com/graphql/graphql-js/pull/2276/files#diff-a2222d77ff884acdf97c5f295babf27cR333-R340)
+   - [Custom Scalar Specification URIs RFC Issue](https://github.com/graphql/graphql-spec/issues/635)
+   - [Custom Scalar Specification URIs RFC PR](https://github.com/graphql/graphql-spec/pull/649)
+   - [GraphQL.js PR](https://github.com/graphql/graphql-js/pull/2276/files)
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
I'd like to provide a minor update on the progress of the "Custom Scalar Specification URIs" work.

I have one question about the implementation, but it should be fairly quick. If possible to have this early in the meeting to knock it out that would be great.