### PR TITLE
Add minutes from Jan, Feb, and Mar 2020 meetings

### DIFF
--- a/notes/2020-01-09.md
+++ b/notes/2020-01-09.md
@@ -1,0 +1,195 @@
+# GraphQL Spec WG January 2020
+
+
+### Agenda
+
+
+
+1. Introduction of attendees (5m, Lee)
+2. Determine volunteers for note taking (2m, Lee)
+3. Review agenda (2m, Lee)
+4. Review [previous meeting's action items](https://github.com/graphql/graphql-wg/blob/master/notes/2019-12-05.md#action-items) (5m, Lee)
+    1. [Currently open action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+5. Discuss possible standardization of stream and defer. [Issue](https://github.com/graphql/graphql-wg/issues/329) (30m Keweiqu)
+6. [Input Union RFC](https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md) (15m, Vince)
+7. Custom Scalar Specification URIs (10m, Matt Farmer and Evan and Andi)
+    2. <code>[graphql-js Pull Request](https://github.com/graphql/graphql-js/pull/2276)</code> is ready for review
+        1. The spec has changed from <code>@specified(by: String)</code> to <code>@specifiedBy(url: String)</code>, and needs minor update
+    3. [graphql/graphql-spec/issues/635](https://github.com/graphql/graphql-spec/issues/635)
+    4. [graphql/graphql-spec/pull/649](https://github.com/graphql/graphql-spec/pull/649)
+    5. Discuss next steps
+8. [Defer and Stream Directives Sketch RFC](https://github.com/graphql/graphql-spec/pull/667) (15m, Liliana)
+
+
+### Review [previous meeting's action items](https://github.com/graphql/graphql-wg/blob/master/notes/2019-12-05.md#action-items) (5m, Lee)
+
+
+
+*   [Currently open action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+*   Lee still needs to look at the January 2020 Spec release 
+*   Ivan has already released GraphQL-js v15.0.0-rc.1 to npm
+
+
+### Discuss possible standardization of stream and defer. [Issue](https://github.com/graphql/graphql-wg/issues/329) (30m Keweiqu)
+
+[Defer and Stream Directives Sketch RFC](https://github.com/graphql/graphql-spec/pull/667) (Liliana)
+
+
+
+*   Facebook have been working on this for 3 years, they think they're coming to maturity for the edge-cases/etc
+*   Have noticed community interest in these topics - want to come together to formalise discussion 
+*   How do we go forward with specification - is it official or separate?
+*   Liliana / 1stdibs: we are willing to put effort into the spec, helping find commonality, etc
+*   Robert: what progress has happened recently?
+*   Kewei: news feed challenges our implementation, and proves that our implementation can handle busy use cases, and ensures we handle edge cases - helps us to think through. How can we continue to optimise it? Led to batched response payloads/etc
+*   Michael: what are the status of the PRs? Are they in line with what you're doing at Facebook?
+*   Kewei: the relay implementation is very aligned with the Facebook implementation
+*   Liliana: The PR we have open is inline with the implementation at Facebook
+*   Michael: our implementation is based on the Relay implementation
+*   Mike: are the two implementation competing or aligned? 
+*   Rob: aligned
+*   Vince: How does this relate to subscriptions?
+*   Michael: run a standard query, and defer just parts of that query - immediately get the non-deferred part, but in subsequent updates receive "patches".
+*   Kewei: defer and stream is about "one payload" that's delivered chunk by chunk; subscriptions are then used to subscribe to long-lived updates
+*    Vince: so defer/stream are not meant to be long-lived?
+*   Kewei: correct
+*   Michael: see talk by Lee Byron relating to batching
+*   Vince: Is there a mechanism for server-side to determine a field should be deferred, or is it all in the client?
+*   Gabriel: although the server might know better what will perform well, it's the client who decides how they want to handle it.
+*   Michael: the client is the most important part, which is why the client is the driver (not the server)
+*   Mike: the client is describing the requirements - here are the highest priority things, versus lower priority that can be returned later. Particularly useful if you're fetching a lot of data.
+*   Lee: A perfectly valid response from a server for a query that contains @defer / @stream is to just completely ignore them - the client places the @defer/stream hints and the server can choose whether or not to defer/stream them.
+*   Matt/Erik: doesn't that let the server overrule what the client has instructed - isn't that strange?
+*   Lee: it's potentially strange, but it gives you backwards compatibility
+*   Lee: all production servers ignore @defer/@stream and so this has to be a valid output for backwards compatibility. Also a server may be smart about it and determine that it's actually more performant to inline something than defer it, so it may override if it knows better.
+*   Gabriel: "defer" tells the server "give this to me when it's ready" and the server can just say "we're already ready" and return it immediately
+*   Kewei: we have use cases at Facebook where the server does indeed override the @defer that the client indicates, and lets the client know about this via the extensions property
+*   Robert: there are a number of use cases for subscriptions that would be better served with @defer - for example a long-lived invite request only has one payload - when the user ultimately accepts the invite. We've implemented it as subscriptions, but it might fit better as @defer. "I expect a single response in the future as to the status of this mutation when it's completed". 
+*   Kewei: we've not used this pattern at Facebook - we hold a HTTP request open for the @defer/@stream operations and it would time out. Definitely interesting to think about it as a callback in a really long-lived connection though.
+*   Robert: the semantics of stating a single response will come after "some amount of time" is really useful
+*   Kewei: the response format (ignoring the transports) is very reasonable and we can have it handle more use cases
+*   Lee: how are these implemented in a transport at Facebook
+*   Kewei: we're using the chunked encoding over HTTP transport 
+*   Lee: we don't talk about HTTP in the spec at all, and it's good to think about this in generic terms so I like how you've been speaking about it - a stream that is expected to close 
+*   Lee: what's next?
+*   Kewei: we want to push this specification forward. What do people think about whether to include it in the official spec or as a supplementary spec.
+*   Lee: IMO main spec, like subscriptions
+*   Kewei: that's what we'd prefer. What are the challenges? Are we introducing new concepts - like HTTP chunked coding?
+*   Michael: we wouldn't need to detail the transport in the spec; the transport part can be in the HTTP spec 
+*   Kewei: focus on request format and response format
+*   Lee: that's right; there's normative and non-normative parts of the spec; we don't want to say you have to use HTTP chunked encoding in the normative part. The abstraction of the stream is already handled in subscriptions, so this is "a stream that is expected to close", and then in a non-normative comment you can state HTTP chunked encoding is what people typically use.
+*   Lee: Ivan & co have been working on GraphQL HTTP spec, so contributing to that spec too would be good.
+*   Dan: given Lee spoke about @defer / @stream 3 years ago there are likely implementations out there that we don't know about. How should we avoid this being a breaking change for people who already have @defer / @stream? We managed it with subscriptions by introducing a new operation type.
+*   Lee: great question: we need to balance spec writing - what's the best solution, and what's the best thing we can roll out?
+*   Lee: we might need to pick different words than @defer / @stream if there are big implementations that cannot migrate easily. Facebook use @fbdefer and @fbstream originally.
+*   ACTION: community outreach - is anyone already using @defer / @stream that might not agree with this new spec?
+*   [ACTION Jesse]: at Apollo we're excited; we've had two PRs for a long time, and there was an alpha version that was cut from that PR and a lot of people were using it. We never officially released it and it's now very out of date, but we're happy to talk to the community and see if anyone is working with it. (I think it's using chunked encoding but not fragments.)
+*   Kewei: first step would be for us to come up with an initial draft, and find out what implementations out there are conforming/non-conforming and try and see what migration will be
+*   Lee: I feel more confident knowing that Apollo's version never left alpha - I think that's the implementation that made it the furthest in the ecosystem.
+*   Lee: it was helpful when we were writing the subscriptions spec to write the implementation and the spec at the same time, and that worked out pretty well. Maybe we can borrow some of the technical pieces from the GraphQL reference implementation.
+*   Michael: the subscriptions spec is more about the "stream" which fits well with defer - we use the same interface in the .NET implementation for subscriptions and defer.
+*   Robert: looking at the async iterator and how it handles errors helped us to write the relevant error handling into the subscriptions spec
+*   [ACTION - Robert? Jafar?] Worth a chat with Tim and Eddy about this. 
+*   Robert: stateless implementation enables scaling. If we're using chunked encoding then we have no distributed state?
+*   Jafar: I've always thought of stream and defer as in-process - it's still stateless (there's state governing the "how", but not the "what") - this seems the right mental model. I wouldn't typically expect interleaving mutations to interrupt the stream. "Consistent within the request." Use memoization/etc to avoid getting two different values for the same field in the same result. Stream and defer are expected to be executed as part of a single process
+*   Robert: so scaling it is a case of stamping out clones?
+*   Jafar: yes.
+*   Kewei: this is a really important question about how a client might handle interleaving requests when requests are long-lived 
+*   Lee: the spec should state that if you encounter the same object twice during resolution you should get the same value back, even if you get the same
+*   Dan: there's cases of name / fullName where later might be inconsistent
+*   Michael: you'd use the same DataLoaders for that
+*   Lee: we should have a non-normative note about what should happen here. ANd how does it interact with subscriptions?
+*   Dan: non-normative makes sense 
+*   Benjie: how does this work with mutations? Multiple mutations would result in fields changing, and when do the defer results get added?
+*   Lee: great point Benjie, if mutation A has a defer in it, does its stream of results have to come to conclusion before we start doing mutation B
+*   Robert: the best solution might be to _not_ maintain consistency. E.g. querying for the "server clock" is expected to change over time - returning the same time for later resolvers is going to cause inconsistencies anyway. I can't see how we can get out of this - we have to accept that a GraphQL response cannot guarantee consistency in all cases.
+*   Jafar: there's a question about what consistency would mean - we don't have identity in the spec, so talking about consistency without identity is challenging. Memoizing every field would be a big space cost - imposing it on all users without being sure that there's sufficient benefit seems like the wrong balance
+*   Lee: it's useful to dig into the weeds to discuss this stuff - but it's important to make a distinction between guarantees and expectations. Even coming up with standardised rules may be challenging. Maybe we should have a rule like "we would expect a query with defer and stream, once it's parts are put together, should be equivalent to if the query had been issued without defer/stream"
+*   Jafar: do we want to make a non-normative note about single-payload responses suggesting that things should be consistent?
+*   Lee: it's really easy for these things to be assumptions for single-payload responses, but when things are spread out over time you have to start second-guessing these assumptions
+*   Jiyue?: we want people to be able to interact with the initial response as early as possible. Users are more likely to act upon the already-rendered screen, which may have a race-condition issue with already returned chunks. Race conditions happen more in the deferred case. Try and alleviate it, but it's hard to guarantee on the server or the client.
+*   Lee: very interesting. We should have a non-normative discussion in the spec itself.
+*   Gabriel: even with non-normative spec text, I don't think we can do any of this stuff - this problem is not unique to GraphQL. MSSQL server had a "READ COMMITTED" / "READ UNCOMMITED" hint; but GraphQL is relying solely on other data sources, so it cannot make any guarantees about getting data that's consistent - especially when the data is delayed.
+*   Jafar: there are different scopes of consistency. Assert: never return the same value with a different value in the response. Need a defined identity for this. There are some subsets of consistency that we could achieve. My opinion is its not worth it.
+*   Lee: there's definitely a lot of interest, and some great discussion here. I'm going to cut us off here because we've been talking for 45 minutes.
+*   Rob: we have a PR with a implementation open against GraphQL-js - we'd like to work together with Facebook on this.
+*   Kewei: we're happy to work together on this - we're looking forward to this collaboration on implementation and spec in parallel!
+*   Lee: I'm super excited about this!
+*   Jafar: thanks for pushing this forward.
+*   Jesse: sorry your PR never landed!
+*   Ivan: regarding the graphql-js PR, can I merge it?
+*   Lee: the RFC document (not the implementation PR?)
+*   Lee: I'm going to merge the spec PR, but the implementation we need to follow up offline
+*   ACTION - Jafar - follow up with Gabriel offline.
+
+
+### [Input Union RFC](https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md) (15m, Vince)
+
+
+
+*   Vince - topics:
+    *   Criteria ranking PR: [https://github.com/graphql/graphql-spec/pull/668](https://github.com/graphql/graphql-spec/pull/668)
+    *   Determine the “worst” solution
+    *   Signup champions for solutions
+    *   Question that has arisen for me:
+        *   Are directives the only way to safely add new features?
+*   Have added gold/silver/bronze weighting - input welcome [https://github.com/graphql/graphql-spec/pull/668](https://github.com/graphql/graphql-spec/pull/668)
+*   There's three tiers; solution number 2 ranks the highest ("configurable discriminator"); then solutions 1 and 5 tie, then 3 and 4. 
+*   3 and 4 either fail or don't fully meet some of the important goals we've laid out, e.g. schema evolution. E.g. if the schema evolves in a particular way then previous operations might have a different result.
+*   Ivan [chat]: "We promise only backward compatibility and only for queries: 
+
+    Once a query is written, it should always mean the same thing and return the same shaped result. Future changes should not change the meaning of existing schema or queries or in any other way cause an existing compliant GraphQL service to become non-compliant for prior versions of the spec. 
+
+    So we can update SDL with new keywords"
+
+*   Vince: two important things
+    *   Semantics of an existing query shouldn't change as the schema evolves
+    *   Adding new keywords to SDL - is that a problem that it might break parsers?
+        *   Jesse: new keywords are okay because all existing queries will remain valid
+        *   Michael: agree
+        *   Lee: agree
+        *   Vince: what if the semantics of a query change (but it still succeeds) - e.g. the type that an input is determined as changes as the schema evolves. Is this acceptable? It seems bad.
+        *   Lee: maybe. Depends on if the result is observable. (We discussed this a couple meetings back.)
+        *   Lee: There are some ways you can evolve a schema that would break old queries. What kinds of queries should we allow people to write? What kind of changes should the schema be able to have?
+*   
+*   Would like to determine which criterias we can cut off, and which solutions we can cut out.
+*   Would also like to determine champions for solutions
+*   Are directives the only way to safely add new features?
+*   Vince: Looks like we’re not yet ready to eliminate any of the alternatives
+*   Lee: I think that’s right. It’s not entirely binary whether a criteria is upheld. This is captured pretty well with the “warning signs”
+*   Vince: Further evaluation is needed. Do we have champions for particular solutions?
+    *   [ACTION: everyone] Make a PR, adding yourself as champion for a solution
+*    Ivan[chat]: I can take discriminator based solutions
+*    Vince: Are directives the only way forward to evolve graphql?
+*    Lee: We need to be able to evolve the language using more than just directives. Directives are a little smoother, but there’s a design tradeoff. If syntax change is clearly a better developer experience, we should take that into consideration.
+*   Kewei: As directive proliferate, we need to consider feature composition
+*   Vince: Even though directives are a mechanism for extensibility, there’s a distinction between query and schema directives. What about exposing schema directives through introspection?
+*   Michael: There are discussions around extending introspection types, but it’s not finalized yet.
+*   Lee: Directives can be complex. We should continue this discussion, but don’t block on this.
+*   Lee: RE: directives vs syntax changes - sometimes you want a guarantee of what a server will do for you. The assumption is that directives may be ignored by implementations. In some cases this is what you want, but it can sometimes lead to surprising behavior.
+*   For client queries you want to know if something serious is ignored, so we can only use directives for things that are safe to ignore. However for servers the requirements are different
+*   Benjie: in the case of @oneOf if a server doesn't support the directive then it won't make that information available via introspection, so the client won't expect the server to honour that directive.
+*   Lee: Next steps - champions for solutions. If a solution fails to get a champion, this is a good indicator that it should be cut.
+    *   Vince: I agree, but just because a solution doesn’t have a champion yet doesn’t mean that it won’t.
+    *   Lee: 💯
+    *   Vince: Timeboxed? Are champions limited to members? (e.g. tc39 requires this)
+    *   Lee: Anybody can be a champion. If we circle back at the next meeting, we can assess at that time.
+
+
+### Custom Scalar Specification URIs (10m, Matt Farmer and Evan and Andi)
+
+
+
+*   <code>[graphql-js Pull Request](https://github.com/graphql/graphql-js/pull/2276)</code> is ready for review
+    *   The spec has changed from <code>@specified(by: String)</code> to <code>@specifiedBy(url: String)</code>, and needs minor update
+*   [graphql/graphql-spec/issues/635](https://github.com/graphql/graphql-spec/issues/635)
+*   [graphql/graphql-spec/pull/649](https://github.com/graphql/graphql-spec/pull/649)
+*   Discuss next steps
+*   Lee: Let’s move this to Stage 2. This will be a DRAFT. Merge PR into graphql-js. 
+*   [ACTION - Lee] I’ll check with Ivan to see if this can be in next release
+*   Matt: Can specifiedBy be used multiple times?
+    *   No, this should fail validation
+    *   [ACTION- Matt] ensure validation fails if specifiedBy is used multiple times
+
+
+### Wrapup

--- a/notes/2020-02-06.md
+++ b/notes/2020-02-06.md
@@ -1,0 +1,262 @@
+# GraphQL WG Notes - Feb 2020
+
+
+## Agenda:
+
+
+
+1. Introduction of attendees (5m, Lee)
+2. Agree to Specification Membership Agreement and Code of Conduct (1m, Lee)
+    *   [Specification Membership Agreement](https://github.com/graphql/foundation)
+    *   [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+    *   [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+3. Determine volunteers for note taking (2m, Lee)
+4. Review agenda (2m, Lee)
+5. Review previous meeting's action items? (Skipped due to agenda coverage) (5m, Lee)
+6. Update on Spec freeze and 2020 release schedule (5m, Lee)
+7. Custom Scalar Specification URIs Update (10m, Matt Farmer)
+    *   Waiting for `graphql-js` `15.0.0` to be cut. Scheduled to be included in `15.1.0` which would be released a week or two later. [Relevant Discussion](https://github.com/graphql/graphql-js/pull/2276#discussion_r367909160).
+    *   Seeking validation on how to handle use-case where a scalar is extended multiple times, which results in the directive being included in the `typeExtensionsMap` multiple times. Currently taking the last element.
+        *   [Test Case](https://github.com/graphql/graphql-js/pull/2276/files#r364908343)
+        *   [Relevant Source code](https://github.com/graphql/graphql-js/pull/2276/files#diff-a2222d77ff884acdf97c5f295babf27cR333-R340)
+    *   [Custom Scalar Specification URIs RFC Issue](https://github.com/graphql/graphql-spec/issues/635)
+    *   [Custom Scalar Specification URIs RFC PR](https://github.com/graphql/graphql-spec/pull/649)
+    *   [GraphQL.js PR](https://github.com/graphql/graphql-js/pull/2276/files)
+8. Discuss deprecation of input fields. There was an older PR ([graphql/graphql-spec/pull/525](https://github.com/graphql/graphql-spec/pull/525)) which seems abandoned. Are there any blocker to move this forward? (15min, Andi)
+9. Discuss full unicode support. There was a PR ([graphql/graphql-spec/pull/231](https://github.com/graphql/graphql-spec/pull/231)) which was never merged. GraphQL Java and GraphQL Ruby and probably more implementation support full unicode support already. What are the challenges here? (15min, Andi)
+10. Discuss backwards compatible introspection: the spec is about to add two new introspection fields (`isRepeatable` and `specifiedBy`) to Introspection. Together with `description` it becomes increasingly difficult for clients to query the full Introspection data. Should there be a more general solution? (15min, Andi)
+11. Discuss @defer and @stream [strawman proposal and questions in the comment](https://github.com/graphql/graphql-spec/pull/679) (30m, Kewei, Jafar, Jennifer)
+12. I'd like to get an idea of what people want from the website redesign (10m, Orta)
+
+
+## Live notes:
+
+
+### Introduction of attendees (5m, Lee)
+
+
+### Agree to Specification Membership Agreement and Code of Conduct (1m, Lee)
+
+
+
+*   [Specification Membership Agreement](https://github.com/graphql/foundation)
+*   [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+*   [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+*   "If you're in the meeting then you know these guidelines and you agree to them - if you don't then speak up"
+*   Silence -> agreement
+
+
+### Determine volunteers for note taking (2m, Lee)
+
+
+### Review agenda (2m, Lee)
+
+
+
+*   Ivan: Google Summer of Code: raise an issue on the foundation issue if you're interested
+    *   https://github.com/graphql/foundation/tree/master/mentorship/2020/gsoc 
+*   Lee: Good point. I’m excited about it. 
+*   ACTION - everyone: if you're interested, get in touch with Lee or Ivan
+*    
+*    
+*    
+
+
+### Review previous meeting's action items? (5m, Lee)
+
+
+
+*     (Skipped due to agenda coverage) 
+*    
+*    
+*    
+*    
+*    
+
+
+### Update on Spec freeze and 2020 release schedule (5m, Lee)
+
+
+
+*   Lee: Proposal: end of today is the freeze for the spec.
+*   Lee: Over the remainder of this month, everyone who’s interested should comb through the draft and look for irregularities
+*   ACTION - everyone: look through the spec and look for irregularities (bugs, spelling mistakes, etc)
+*   Lee: Bryan, our program manager will make sure whoever has contributed to the spec has the proper legal documents
+*   ACTION - Bryan: make sure everyone who has contributed has the proper legal documents
+*   Lee: I'll be writing up the release notes - particularly how this release is different to previous releases
+*   Michael: review will be easier if we can tag what's changed
+*   Lee: That’s a good suggestion. Have a bullet list, a high level explainer of the important changes. Different forms of release notes for different purposes. 
+*   Lee: We can tag all the merged PRs as Spec2020
+*   Ivan: last time we released the spec, Lee asked people to write articles that we could link to, but no-one did this. If someone wants to work on this article they can start now after feature freeze and we can reference this article.
+*   Lee: That’s a great suggestion. An important part is a press plan.
+*   Lee: I'm happy to review anything, help with editing, or anything else that people need help with 
+*   Andi: I might write a blogpost about the interface hierarchy. 
+*   Lee: Mike has also written one
+*   Andi: I am interested to know what happens after the freeze. 
+*   Lee: _disallow non-breaking change_ is in the approved/accepted state - I plan to merge that today after I review it one more time. The reference implementation has been in place for months if not a year. Custom scalar spec is not quite ready yet; missing the cut is not a big deal - all of the reference implementations track the draft rather than a specific version of the spec.
+*   Ivan: does this affect graphql-js? Can we keep merging stage 2 features?
+*   Lee: graphql-js should keep on tracking draft
+*   Lee: What the freeze means from a tactical standpoint is that PR outside of the RFC folder will not be merged for a couple of weeks. 
+*   Lee: The only thing it might affect is custom scalars, which will just delay it for a few weeks. 
+
+
+### Custom Scalar Specification URIs Update (10m, Matt Farmer)
+
+
+
+*   Waiting for `graphql-js` `15.0.0` to be cut. Scheduled to be included in `15.1.0` which would be released a week or two later. [Relevant Discussion](https://github.com/graphql/graphql-js/pull/2276#discussion_r367909160).
+*   Seeking validation on how to handle use-case where a scalar is extended multiple times, which results in the directive being included in the `typeExtensionsMap` multiple times. Currently taking the last element.
+    *   [Test Case](https://github.com/graphql/graphql-js/pull/2276/files#r364908343)
+    *   [Relevant Source code](https://github.com/graphql/graphql-js/pull/2276/files#diff-a2222d77ff884acdf97c5f295babf27cR333-R340)
+*   [Custom Scalar Specification URIs RFC Issue](https://github.com/graphql/graphql-spec/issues/635)
+*   [Custom Scalar Specification URIs RFC PR](https://github.com/graphql/graphql-spec/pull/649)
+*   [GraphQL.js PR](https://github.com/graphql/graphql-js/pull/2276/files)
+*    ---
+*   Matt: waiting on GraphQL 15 to be cut - on hold because of this.
+*   Matt: the specified directive should only be present once; however if you extend a type then the directive might be used multiple times which would be invalid - how do we handle this - should we just take the last one?
+*   Lee: My understanding is that the spec text forbids that.
+*   Evan: Yeah, I believe it would be invalid at that point. If it is trying to override an existing directive. 
+*   Matt: so is that a bug in the GraphQL.js implementation?
+*   Ivan: I think you added a test for this. It should be validated; I probably only need to check one thing - if you create the schema programmatically but then extend it with SDL.
+*   Matt: in the agenda notes, there’s are two test cases and it sounds like the second one should have thrown an error but currently it doesn’t
+*   ACTION - Matt/Ivan: check if this extra check is required, or if there is a bug.
+*   Ivan: I encourage everybody to check the spec because we changed the wording “specified” to “specified by” (a number of similar changes)
+*   ACTION - everyone: check the spec and implementation to make sure you're happy with these changes.
+*   Lee: Matt, it sounds like you exactly have the right framing. The test case looks incorrect to me as well. The second one should cause a validation error. 
+*   Matt: My initial thought is that we should separate this into two different issues. 
+*   Ivan: I’ll try to review it. It is probably a bug. We added this validation pretty recently, a bit over a year ago, so there might be a bug in there. 
+*   Lee: I agree, Matt. We should consider treating this as a separate issue. 
+*   Andi: I started implementing it in GraphQL.js but we should provide guidance from an implementation point of view in the case that there are conflicting directives. For example, if someone updates and there is a new default directive, what should he/she do? This is a bit of an edge case. 
+*   Lee: This is kind of a grey area. We don’t describe how to be compliant when we are not compliant. 
+*   Andi: What should make a call one way or another. Nobody is intentionally against it. It’s just an edge case. 
+*   Lee: Technically it’s spec breaking. It is illegal. 
+*   Andi: Then we should just clarify that case. 
+*   Evan: it's implicitly spec breaking because you cannot have two directives with the same name, and the built in one is automatically included.
+*   Michael: For example, the deprecated directive, it is a part of the SDL. 
+*   Andi: the spec states that you should include the deprecated directive.
+*   Andi: we should state that it's forbidden to declare the directive "@specifiedBy"
+*   Lee: I think that is a good suggestion. One thing we can do is make the spec more clear. We do this for scalar types. For example, we explicitly say that you cannot supply your own String type that behaves in a different way. 
+*   The intent was to do the same thing for the directives, but we were a little more terse with directives than we needed to be.  See: [http://spec.graphql.org/draft/#note-29c86](http://spec.graphql.org/draft/#note-29c86)
+*   Ivan [chat]: [http://spec.graphql.org/draft/#sel-FAHnBXFCAACCbvwP](http://spec.graphql.org/draft/#sel-FAHnBXFCAACCbvwP)
+*   Andi: I just think that we are introducing a new directive, that this issue is more apparent. 
+*   Pascal: I remember there was a best practice for prefixing directives. 
+*   Lee: It’s related but it’s not exactly what Andi is talking about. 
+    *   http://spec.graphql.org/draft/#note-29c86
+*   Pascal: The thing is you have to prefix all directives. It feels weird that the custom directives have to be prefixed (because there are a lot more custom directives than built in)
+*   Ivan: I'm not sure we need to add anything right now; but I kind of agree that forcing everyone to prefix all their custom directives is undesirable.
+*   Lee: Yeah, that’s why this is a non-normative suggestion and not a rule. I think either stopping people from starting up their GraphQL server or allowing the override and continue to chug along the best we can are both possible routes. We just need to be clear about it. 
+*   Andi: we should be explicit in the spec about this 
+*   Lee: agreed; I will be adding this change
+*   ACTION - Lee: add a change to the spec making this clear
+*   jhusain: has this issue been considered in the context of namespaces before. I searched for it, and heard about Facebook talking about using namespaces in 2017 but couldn't find conclusions - has this been considered recently?
+*   Lee: I think it has not been considered recently. There was discussion about this in 2017-2018. It can be kind of tricky to track with different namespaces. There was an idea to have all the built in types to be in their own namespace. You always need to resolve to the correct namespace and that ended up being very tricky. It just introduced more oddities. However, I don’t think this means that namespaces solution is a deadend.
+*   Lee: "It looked like a solution looking for a problem."
+*   jhusain: can you point us to these specific issues/places where this was discussed?
+*   Lee: I think this was all discussed live, so check the notes. I believe it was also discussed in the GraphQL Spec issues and the GraphQL.js issues on GitHub. 
+
+
+### Discuss deprecation of input fields. (15min, Andi)
+
+
+
+*   There was an older PR ([graphql/graphql-spec/pull/525](https://github.com/graphql/graphql-spec/pull/525)) which seems abandoned. Are there any blocker to move this forward?
+*   Andi: Deprecating arguments and input fields happens in the wild, it feels like a missing piece of GraphQL.
+*   Ivan: I reviewed it today, and remembered the entire discussion. Someone created the PR for spec repo, but never attended the working group, we discussed it without him. Agreement was that after GraphQL.js PR is ready it can be fast-forwarded. It's my fault; solution is to ask the original author if they want to move it forward, if not then someone else can take over.
+*   I reviewed it today; the only thing missing is the introspection part - we might need to add an extra flag. Actually... we might need two stage introspection for this.
+*   ACTION - Ivan/Andi: ping the original author.
+*   Andi: I’m happy to help out if the GraphQL.js is the only thing missing from the PR. 
+*   Lee: sounds good to me; it just needs a champion.
+
+
+### Discuss full unicode support. (15min, Andi)
+
+
+
+*   There was a PR ([graphql/graphql-spec/pull/231](https://github.com/graphql/graphql-spec/pull/231)) which was never merged. GraphQL Java and GraphQL Ruby and probably more implementation support full unicode support already. What are the challenges here? 
+*   Andi: This is more in the realm of hygiene. Currently, there is a restriction to the Basic Multilingual Plane - covers all written communications but doesn’t cover emojis for example. In real life, our implementation allows all unicode in descriptions. 
+*   Andi: Lee opened a PR quite early (like 4 years ago) and there was discussion but then it was abandoned. 
+*   Lee: I’ll talk about it because it is my PR. I think I abandoned it because I didn’t have the time or context to take it to a conclusion. There were a lot of specific edge cases and I didn’t have confidence that the change I was trying to make was the right one. There are no objections to multilingual planes. However, the question is what happens if you are in an environment that doesn’t support multilingual planes. 
+*   Lee: JS historically had really bad support for this (but it's got better now); this was one of the reasons we got stuck.
+*   Michael: .NET has recently added support for UTF8 JSON (previously we could only do it in UTF16); this is great for performance and compatibility.
+*   Lee: That’s a good point. So there might be performance implications for supporting multilingual planes.
+*   Andi: unicode stuff is similar to timezone stuff - edge cases get tricky and the common understanding of edge-cases is not there. I'm not a Unicode expert. One thing in the Unicode spec is that there are two different things - what unicode represents and how to encode these things. The [GraphQL] spec could be more more clear that these concerns live outside of our spec.
+*    Andi: question: do we want to allow escape strings with more than 4 digits for codepoints outside of the BNP? This seems like the most critical thing. There could be performance implications if a system does not support it well.
+*   Michael: in .NET a string is UTF16, which has space concerns if you're reading in a UTF8 string. We had to do a lot of work around UTF8. You're inflating strings by default if you state that GraphQL strings _have_ to be UTF8.
+*   Andi: This is not what I’m talking about. The spec doesn’t tell you how to encode anything. 
+*   Michael: the spec states that the string is UTF8 
+*   Andi: No, the spec does not say that it has to be in UTF8
+*   Lee: This is just wrong. What Andi is suggesting is correct. We should not say anything about the encoding in the spec. Andi, if you want to champion this issue, here are some ideas:
+*   ACTION - Andi: split this into separate pieces so that we can think about the implications of each. 1. comb through the spec and make sure that we're consistent between "character" and "codepoint". Whenever we say "character" we mean "codepoint"; whenever we say "UTF8" we mean "Unicode". 2. Change what codepoints are allowed. It's weird that some GraphQL implementations are non-compliant because they support characters outside of the BNP. 3. Multi-plane escape sequences. 
+*   Jesse: the null character is problematic, e.g. in PostgreSQL the null character is not allowed. This is a problem for interoperability.
+*   Andi: this is kind of a hygiene thing, I'm happy that we're going to try and address this. 
+*   Full unicode support would be wonderful.
+*   Lee: I'm really happy you're looking into this.
+*   Ivan: one small note, I submitted a project for GraphQL-cats to Google Summer of Code - it would be great to have Unicode tests in this so we get half a year to make sure that all implementations agree on this.
+*    
+*     
+
+
+### Discuss backwards compatible introspection (15min, Andi)
+
+
+
+*   "the spec is about to add two new introspection fields (`isRepeatable` and `~~specifiedBy~~`) to Introspection. Together with `description` it becomes increasingly difficult for clients to query the full Introspection data. Should there be a more general solution?"
+*   Matt [chat] Minor correction: ``specifiedByURL`` is what is currently being proposed to be added (no longer ``specifiedBy``)
+*   Andi: Fundamental challenge is related to the introspection query. You have to specify every field you want. We added 3 new fields with the soon to be released spec. The description to the schema, the http to scalars, etc. There is a general challenge of how to evolve introspection moving forward. 
+*   Ivan [chat]: [https://docs.google.com/presentation/d/1ISS5QhF6D2ncD8ZGChoCv1LnOWj9jryZrJ2dG11i4Mc/edit?usp=sharing](https://docs.google.com/presentation/d/1ISS5QhF6D2ncD8ZGChoCv1LnOWj9jryZrJ2dG11i4Mc/edit?usp=sharing)
+*   Michael: what we do is we do 2-phase introspection - first query checks for all of the optional things - e.g. asking for the subscription type. From the results of this we then generate the introspection query. So for 2 phase introspection the first phase may change over time.
+*   Ivan: We discussed it in a previous WG. Lee initially suggested multi-stage introspection. I don’t want to add more experimental or breaking stuff. After 15.0.0 release, we’ll do proper 2-phase introspection. 
+    *   https://docs.google.com/presentation/d/1ISS5QhF6D2ncD8ZGChoCv1LnOWj9jryZrJ2dG11i4Mc/edit?usp=sharing
+*   Ivan: we're using flags for each of the features currently.
+*   Lee: I wonder if there is anything in the future that can replace introspection. I don’t want to set things up so that this isn’t something we can explore in the future. We’ve been talking about 2-phase introspection for forever. If introspection is going to be core, then it’s going to be replicated for every language, and we should clarify how to do it in the spec. Add it as a chapter to the introspection chapter. 
+*   Lee: If anyone thinks that their implementation of 2-phase introspection is really bullet-proof and future-proof; lets start writing it up!
+*   ~~ACTION - anyone who has implemented 2 phase introspection: volunteer to be involved with writing this up~~
+*   Ivan: just to confirm, this would be a non-normative note?
+*   Lee: I don't know if there is anything normative or not. Probably non-normative? Lets not get hung up on the details of it; if we agree that it's valuable to write this up separately from source code lets start doing that. 
+*   Andi: I think introspection is extremely critical to the GraphQL ecosystem. Even if it is a non-normative note, it is something we should discuss. 
+*   Ivan: Actually, I like the flexibility of introspection. That’s why I’m partial to keeping it a non-normative note. 
+*   Ivan [chat]: [https://github.com/graphql/graphql-spec/pull/319](https://github.com/graphql/graphql-spec/pull/319)
+*   ACTION - Michael: have a go at writing this up
+*   Lee: rejected RFCs don't feel great, but they are a really good way of documenting process to explain why we've not followed a particular path. I just want to make it clear that this could still be a useful thing to do.
+*   Lee: We have 1-phase introspection already specified in the spec (though you can ignore it if you want to) - making sure this stays up to date is really important, and there's space in the spec to add details about 2-phase here.
+
+
+### Discuss @defer and @stream (30m, Kewei, Jafar, Jennifer)
+
+
+
+*   [Strawman proposal and questions in the comment](https://github.com/graphql/graphql-spec/pull/679) 
+*   Kewei: I submitted a PR that added content to Liana’s original RFC. Possible changes to improve latency, the difference between subscriptions and defer stream. 
+*   Kewei: Defer/stream are NOT to represent real-time changes.
+*   Kewei: I have a lot of questions about what to include in the refer/stream spec
+*   Kewei: Defer is a low level paradigm. Execute this piece of code asynchronously. Something that is more high-level might be more valuable. For example, let’s say there is a piece of data that I will need in the future. The way the server can handle it could be synchronously or asynchronously. 
+*   Kewei: What do people think about tabling the @defer part in favour of a higher level abstraction in the future?
+*    Lee: Successful RFCs first describe a problem space but yields much higher quality results. It sounds like you’re already thinking about this in a broader perspective. 
+*   Kewei: I think we should save @defer discussion for the future
+*   Lee: I think it might make sense to separate defer and stream. The original pitch is stream would operate on arrays of things and defer would operate on singletons. There is a parallel in React concur list, it allows you to wait for things in ordered arrays. 
+*   Kewei: I’ll definitely capture my thoughts in the RFC more. Basically the concern is if we standardize defer now, it might restrict new features in the future. 
+*   Kewei: The second question is that at Facebook, when we experimented with defer and stream, we also added a lot of other features like batched payloads. I was wondering which of these features would be valuable to include in the spec. 
+*   Lee: That’s a good question. Some things to consider. Does doing one thing make it harder to do another thing? It’s not about whether things are simple or complex, what’s more important is describing ideas in detail. The behavior should be very well defined. 
+*   Kewei: I think a lot of these are more detailed questions. 
+*   Andi: I am interested in how you implemented your overall system. Just want to make sure the overall idea makes sense.
+*   Michael: There was a good talk from Robert Zhu.  
+*   Kewei: It is an attempt to represent promises and futures like in other languages. The connection is very short lived. Everyone can implement their own async iterators that represent the data to be returned, and the system pulls from these. It is not realtime - we do not use pub/sub for it.
+*   Lee: If you or anyone is interested in doing a tech talk or a blogpost, I think there would be a lot of avid readers. 
+*   Lee: If we had to write an execution spec text, what would that look like? This is going to be the hardest part of defer and stream. 
+*   Kewei: The interesting thing about implementing defer and stream is that the two behave very differently. Stream resolver returns an async iterator. With defer, we had to change the executor logic, this is asynchronous code, we’re not going to await for it, we are going to store the deferred piece of code in the queue. 
+*   Kewei: We have a lot of additional context that would be useful to the end user of the defer and stream. They wouldn’t be helpful for the implementers of defer and stream. It feels it wouldn’t be appropriate to put it in the spec but where should this information live?
+*   Lee: I think we can consider putting it in the spec. The FAQ should be mixed in with the spec. That way the spec is more than a description about implementing GraphQL, it is also a way to learn about it. 
+*   Kewei: Okay, we can first try to include information in the spec and if it’s too much, we can move it elsewhere. 
+*   Kewei: Is the current RFC considered the strawman?
+*   Lee: I think right now it is. 
+*   Ivan: I think so too. 
+*   Kewei and Liliana will champion this idea and will talk to each other
+*   Lee: I think it makes sense to move this to stage 1.
+*   Action - Lee: move to stage 1
+*   Kewei: sounds good!
+
+
+### I'd like to get an idea of what people want from the website redesign (10m, Orta)
+
+*   Orta is not here today
+*   Action: Move to next wg’s agenda

--- a/notes/2020-03-05.md
+++ b/notes/2020-03-05.md
@@ -1,0 +1,288 @@
+# GraphQL WG Notes - March 2020
+
+
+### Agenda
+
+
+
+*   Introduction of attendees (5m, Lee)
+*   Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Lee)
+    *   [Specification Membership Agreement](https://github.com/graphql/foundation)
+    *   [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+    *   [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+*   Determine volunteers for note taking (2m, Lee)
+*   Review agenda (2m, Lee)
+*   Custom Scalar Specification URIs Update (10m, Matt Farmer)
+    *   Still waiting for `graphql-js` `15.0.0` to be cut. Scheduled to be included in `15.1.0` which would be released a week or two later. [Relevant Discussion](https://github.com/graphql/graphql-js/pull/2276#discussion_r367909160).
+    *   PR has been rebased off of `v15.0.0-rc.2`
+    *   [Custom Scalar Specification URIs RFC Issue](https://github.com/graphql/graphql-spec/issues/635)
+    *   [Custom Scalar Specification URIs RFC PR](https://github.com/graphql/graphql-spec/pull/649)
+    *   [GraphQL.js PR](https://github.com/graphql/graphql-js/pull/2276/files)
+    *   Question: should the spec suggest or require that implementations validate the URL is well-formed?
+*   Union fields with the same name but different types (10m, Sasha Solomon)
+    *   Discuss if this is an issue and if it can be addressed and the reasons behind the original change.
+    *   Relevant issues/links:
+        *   [issue with a lot of discussion](https://github.com/graphql/graphql-js/issues/53)
+        *   [original issue in Sangria](https://github.com/sangria-graphql/sangria/issues/310)
+        *   [related issue in Sangria](https://github.com/sangria-graphql/sangria/issues/436)
+        *   [more recent similar issue](https://github.com/dotansimha/graphql-code-generator/issues/2781)
+        *   [change disallowing this behavior](https://github.com/graphql/graphql-spec/pull/162)
+*   Input Union RFC (10m, Vince Foley)
+    *   [graphql/graphql-spec:rfcs/InputUnion.md@master](https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md)
+*   `@defer`/`@stream` (30m, Rob/Liliana/Jafar/Kewei)
+    *   [Batched Responses](https://github.com/graphql/graphql-spec/pull/692)
+
+
+### Introduction of attendees (5m, Lee)
+
+
+### Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Lee)
+
+
+
+*   [Specification Membership Agreement](https://github.com/graphql/foundation)
+*   [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+*   [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+
+
+### Determine volunteers for note taking (2m, Lee)
+
+
+
+*   Benjie
+
+
+### Review agenda (2m, Lee)
+
+
+
+*   Two new topics added (see below)
+
+
+### Custom Scalar Specification URIs Update (10m, Matt Farmer)
+
+
+
+*   Still waiting for `graphql-js` `15.0.0` to be cut. Scheduled to be included in `15.1.0` which would be released a week or two later. [Relevant Discussion](https://github.com/graphql/graphql-js/pull/2276#discussion_r367909160).
+*   PR has been rebased off of `v15.0.0-rc.2`
+*   [Custom Scalar Specification URIs RFC Issue](https://github.com/graphql/graphql-spec/issues/635)
+*   [Custom Scalar Specification URIs RFC PR](https://github.com/graphql/graphql-spec/pull/649)
+*   [GraphQL.js PR](https://github.com/graphql/graphql-js/pull/2276/files)
+*   Question: should the spec suggest or require that implementations validate the URL is well-formed?
+*   Lee: what value does it add beyond pedantic correctness?
+*   Matthew Farmer: If GraphiQL or other tooling depends on it, we shouldn't pass the validation of this on to them.
+*   Evan Huus: We can use the IETF RFC for URL validation.
+*   Andi: this is almost recursive, since URL parsing is non-trivial. You'll potentially end up with incompatible implementations. I'm not sure it's not adding value.
+*   Lee: I agree with Andi. Precedent: if you put a malformed URL into an HTML anchor tag the page will still render.
+*   Lee: the fact it's a URL is only a human concern; to tools it's an opaque string. 
+*   Morris: Even if it's a valid URL you may not be able to click it.
+*   Evan: we can always add it later if it becomes a problem.
+*   Lee: the power of these specified by URLs only become powerful when clients and servers agree.
+*   Matthew Farmer: I agree; but devil's advocate to adding it later - adding it later would be a breaking change; adding it now would not be.
+*   Lee: it could potentially be breaking
+*   Matthew: I rebased last night, Ivan has given me feedback yesterday which I can look at today.
+*   Matthew: Is this going to be in GraphQL 2020?
+*   Lee: I'd like to draw a hard line - this will be the first major [thing] to be in the 2021 spec cut. People track the draft more than the releases.
+
+
+### Union fields with the same name but different types (10m, Sasha Solomon)
+
+
+
+*   Discuss if this is an issue and if it can be addressed and the reasons behind the original change.
+*   Relevant issues/links:
+    *   [issue with a lot of discussion](https://github.com/graphql/graphql-js/issues/53)
+    *   [original issue in Sangria](https://github.com/sangria-graphql/sangria/issues/310)
+    *   [related issue in Sangria](https://github.com/sangria-graphql/sangria/issues/436)
+    *   [more recent similar issue](https://github.com/dotansimha/graphql-code-generator/issues/2781)
+    *   [change disallowing this behavior](https://github.com/graphql/graphql-spec/pull/162)
+*   Sasha: Why was the change made? Was it deliberate? Can we move forward towards taking this restriction out?
+*   Lee: the original concern was that the payload of that object would have a single "reason" field (based on the example) and the type of that field is unknown because `__typename` has not also been queried. So if you're a strictly parsing client you may not be able to proceed. For example if you have `a: Date` and `a: URL` (both custom scalars) then the client cannot know whether to treat the value of `a` as a `Date` or a `URL` - the consumer does not have enough information to deserialize the JSON into local objects.
+*   Mike: this is a client issue - they've explicitly asked for ambiguous results.
+*   Michael: the client can always ask for the __typename
+*   Mike: or alias the field.
+*   Sasha: clients that we're using are able to differentiate, but are being forced to use aliases.
+*   Mike: this only fixes a smaller issue because field arguments prevent merging.
+*   Michael: these are separate types/separate selection sets so the selection set do not get merged
+*   Evan: you could reproduce this with interfaces
+*   Michael: this is a separate issue with scalars
+*   Mike: I agree. This won't solve all conflict issues. 
+*   Kewei: at GraphQL conf last year [Matt Mohoney had a talk](https://www.youtube.com/watch?v=Vo8nqjiKI3A) about this. At Facebook we group all of these issues under the name "Fat Interface". In order to prevent developers ever writing conflicts we have to do a full schema validation checking for conflicts everywhere. Causes a ridiculous build time, or write tests that takes 5 minutes to run. MM talked about modular fragment model that doesn't rely on this "Fat Interface Model" or having to resolve the union names.  
+*   Mike: I'll definitely check that out.
+*   Sasha: what's the path forward? This is something we've hit into a lot at Twitter. Is this something we could change?
+*   Andi: is this only for unions, or also for interfaces?
+*   Kewei: it's the same problem if the interface does not specify these fields
+*   Andi: we had edge cases in the past where the current spec doesn't capture all conditions, we should explore this if we want to go further
+*   Greg: I think this problem has another root to the problem. When the fields are merged one is chosen and the others are collapsed.
+*   Lee: this is one validation rule in a family of validation rules about how selection sets are allowed to exist and interact. It solves two problems:
+    *   Is the query unambiguous to run? This is about arguments -> if you see two fields with different arguments you won't know which one to run. We don't want to change this.
+    *   Something could be completely unambiguous to run on the server, but ambiguous on the client. That is what we're talking about there.
+*   Lee: Historical context: originally it was expected that all validation would be done on the server. There was only one set of rules for validation, so they are strict since it has to make sure that the queries are unambiguous for both server and client.
+*   Lee: Sasha you could start to look at what separating these two rules would be like. Can we take this rule out? Is it okay for response payloads to be potentially ambiguous? The client can make it unambiguous - it's on the client to do that.
+*   Lee: Should there be a tool or a something in the spec to detail what the client's responsibilities are related to this. We've talked about "GraphQL Linter" in the past. Perhaps this rule doesn't go away, but it's optional?
+*   Lee: one last thing - the validation rules are not always perfect in validation, they assume they'll be run as part of the group. Conflicting argument names does not recurse - it assumes that if there are two fields with different types being returned it that it's going to fail elsewhere. So we could get back to the server ambiguity case if we remove a rule to make sure we've not broken any edge cases.
+*   Sasha: I can see how this would be a problem from digging in the Sangria code.
+*   Greg: how does this impact the client in general if I have a client that uses an interface or union, and the server resolves, and the client specifies fragments on different types.
+*   Lee: exactly, we're talking about unions here, but really the problem is on fragment spreads. We can get into a situation where the payload is ambiguous on the client. The question here is: "is that okay?" Is it okay to put the burden of this on the client?
+*   Greg: there's always the spec defined __typename, so that should be the discriminator for the client, so maybe we need to say in the spec something like: please ask for additional type information and then we can decide what to do.
+*   Lee: there's an interesting question here: should we completely remove the client ambiguity protections from the spec and allow this wholesale, or should we have something that disambiguates.
+*   Evan: there's definitely something to be said for preventing people from going down a path that makes it easy for them to shoot themselves in the foot. We avoid this category of issues by being strict about this in the spec.
+*   Ivan: we also need to think about other programming languages where a type needs to be defined for a specific fragment; e.g. where code generation in a very strict language and __typename is not sufficient because there's no way to handle disjoint unions.
+*   Lee: Objective-C and Java did not have a way to implement disjoint unions which is why this validation rule was added.
+*   Lee: "should this be a spec'd rule that affects all clients, or should it be left to the client?"
+*   Lee: our code generators used to validate the query first and only generate the code if it validated and was non-ambiguous.
+*   Lee: we were worried that problems would be detected late (i.e. at the code generators stage) rather than giving you realtime feedback in your editor. That's part of the historical context.
+*   Sasha: Action: Piece all of this together and come up with some kind of proposal. 
+*   Lee: this at least shows that it was worth discussing!
+*   If anyone is interested, ping Sasha an email.
+
+
+### Full unicode support [graphql/graphql-spec/issues/687](https://github.com/graphql/graphql-spec/issues/687) (10 min)
+
+
+
+*   Andi: I've raised a PR against graphql-js and a spec issue to discuss about extending to full Unicode support. Other language (e.g. ruby) already support this, but were not tested, so I've added tests. And in graphql-js added a validation rule.
+*   Looking for feedback and how to move forward. It's basically a cleanup. The big change in the spec would be to change the range of codepoints to support full unicode.
+*   Lee: does this cover everything that you want full unicode support to cover, or is it a first step?
+*   Andi: everything.
+*   Andi: Lee raised a PR that removed a lot of the restrictions which lead to some interesting discussion around control characters 2 years ago, this builds on that factoring in the discussion.
+*   Lee: you should address multilingual plane control characters. I think the PR currently only handles surrogate pairs?
+*   Andi: we already have escape codes inside the BMP; this PR uses surrogate pair escapes and leans on JSON to escape codepoints outside the BMP. I didn't want to add any new syntax or new way of doing escape codes, so this is the most minimal change.
+*   Lee: if the thesis of this change is having first class unicode support, the surrogate pairs is kind of a hack to expand code that wasn't designed to handle full unicode support to actually meet it. The Math to turn a surrogate pair into a full codepoint is complex.
+*   Andi: there's a reason people invented the more convenient 6-digit escape codes to handle this.
+*   Andi: I didn't see a reason to prevent surrogate pairs
+*   Lee: good point - we shouldn't prevent people doing this; but it's definitely worth having the escape sequence in addition.
+*   Lee: I'd like to see you turn this into a spec PR also.
+*   Andi: happy to open a PR
+*   ACTION - Andi - open a PR
+*   Ivan: are you supporting surrogate pairs, variable length, or both?
+*   Andi: this PR adds surrogate pairs, but Lee is suggesting that we should also add the 6-digit escaping
+*   Ivan: JSON only supports surrogate pairs, so adding the other escape form may be surprising. JSON the dominating format, so having something that is different would be weird.
+*   Lee: I hear you, but before this we didn't have surrogate pairs support, right?
+*   Andi: actually we did, because Java and JavaScript use UTF16, we just didn't have tests for it or mention it in the spec.
+*   Lee: I was on the fence about surrogate pairs, but since we already supported it implicitly making sure we support it explicitly makes sense.
+
+
+### Input Union RFC (10m, Vince Foley)
+
+
+
+*   [graphql/graphql-spec:rfcs/InputUnion.md@master](https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md)
+*   Vince: Mostly there hasn't been a lot of activity and my time has been eaten up
+*   Vince: Lee opened a PR adding himself as a champion to one of them
+*   Vince: I've added myself as a champion to two of them. Benjie wrote the 
+*   Benjie: oops, I thought I had added myself as champion - I'll add a PR
+*   ACTION - Benjie - add yourself as a champion to the Input Union spec
+*   Vince: I'm adding myself as a champion of it too, I think it should be in anyway
+*   Evan: I'll add myself as a champion for number one with the explicit __typename
+*   ACTION - Evan - add yourself as a champion - Done [https://github.com/graphql/graphql-spec/pull/696](https://github.com/graphql/graphql-spec/pull/696)
+*   Vince: what's the job of a champion going to be here?
+*   Lee: it's on us to push on this a little bit. I've also been slogged down on other non-GraphQL things.
+*   Lee: one idea is that we can have an out-of-schedule one-off meeting for the champions to meet alone, and hopefully we can come back with some clarity. Maybe we should have some homework before we do that.
+*   Lee: the job of the champion is to hold the null hypothesis - "I'm excited by this one but it's on me to set this one down when something else is more exciting"
+*   It's hard to do this because we've been working on this for a long time; but if you want to be a champion expect to do movement on these.
+*   Gabriel: (potential agenda item) - one thing that we could improve is details around oru processes and roles - it's not so clear what a "champion" involves and how to be one. TC39 has great documentation around this, we could work on having something like that.
+*   Lee: I agree, we have some guidelines on this (not as detailed as TC39) but we at least have definitions for what a champion is and what the stages are: [https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md)
+*   ACTION - Lee - Add [https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md)
+
+     to the agenda template
+
+*   Gabriel - I'll look through this and maybe submit some changes
+*   ACTION - Gabriel - contribute to CONTRIBUTING.md
+*   Lee: I've written this mostly myself, and I'd love suggestions on how to improve it.
+*   Vince: I think having a meeting of the champions is a great idea.
+*   Vince: note that more than one person can put themselves down as a champion for an idea. That's a bit of a signal. Would you agree Lee?
+*   Lee: I think you're right; but the role of a champion is someone who's willing to do the work on something; if they're communicating well then it may be fine, but it's easy to get into the situation where each person is expecting the other to do the work.
+*   Lee: certainly you shouldn't take the sign that someone else is the champion for blocking you from helping.
+*   Vince: lets give a bit of time to get everyone to get their PRs in, then have a meeting in 2 weeks?
+*   Lee: maybe 3 weeks - 1 week before the next week
+*   ACTION - Vince to open an issue to discuss when we'll have it exactly.
+    *   [https://github.com/graphql/graphql-wg/issues/378](https://github.com/graphql/graphql-wg/issues/378)
+
+
+### Move "Add deprecated directive to arguments and input values" to stage2 RFC graphql-js RFC (10m, Ivan)
+
+
+
+*   In a nutshell: we can deprecate fields and enum values, but not fields within input types or arguments.
+*   A year ago we agreed to fastforward this. I contacted the original author and he raised a GraphQL Spec and GraphQL.js PR. There's a couple things missing from the GraphQL.js PR
+*   Should we forbid deprecating required arguments/input fields?
+*   I don't want to add additional restrictions on directives. For me I don't see any big issue to deprecating a required argument.
+*   I don't mind if it doesn't go into GraphQL 2020 but I'd like to merge it into GraphQL.js.
+*   Lee: the PRs are not in a state where they're ready for Stage 2 yet. The Spec PR is a bit of a mess.
+*   Ivan: I think went something went wrong on the branch, I can rebase it - I reviewed it before and it was in a good shape.
+*   Lee: suggestion - stage 1 today and raise it to stage 2 offline if these are in a good shape.
+*   RESOLUTION (Lee) - moved to stage 1
+*   ACTION - Ivan - get these PRs into a good state
+
+
+### @defer/@stream (30m, Rob/Liliana/Jafar/Kewei)
+
+
+
+*   [Batched Responses](https://github.com/graphql/graphql-spec/pull/692)
+*   If the server dumps a bunch of patches really quickly it could cause a client to re-render really frequently negating the gains of defer
+*   Debouncing on the client is a simple solution, but it's hard to figure out what the right number is to debounce by, and the debounce adds latency.
+*   Server could debounce; we should put in the spec there's these two different options.
+*   Server should only do this if it understands how the data is coming in, otherwise you get the same problems as on the client.
+*   Server can treat @defer and @stream as a hint.
+*   Lee: to confirm
+    *   Whether @defer / @stream are rules vs hints.
+        *   Personal opinion: yes, server should be able to decide this.
+    *   What's the actual response shape?
+        *   Is it a stream?
+        *   Can multiple items happen simultaneously?
+        *   The main task here is documenting the stream and response format.
+*   Jafar: is there any value on being able to configure a server debounce, e.g. `@stream(debounce: ...)`. Can we get away without (adding this to the protocol)?
+*   Lee: If your server is naively streaming things and they're tightly packed together then performance can be limited by react re-renders. This is a specific problem for React, for other kinds of clients it might be less of an issue. Other iOS clients I've worked with have streamed GraphQL into the database and then rendered those back out separately which works around this issue.
+*   Lee: the server needs some flexibility to deliver things in the right order. It needs to do both what's best for it whilst also keeping in mind the clients' needs and restrictions.
+*   Lee: we tried a client debounce for the React rendering problem - the performance was about the same or worse, latency was worse even though the CPU churn was less.
+*   Jafar - that's the context I was looking for there. The value in the server delivering batches is that the server has context the client does not, so letting the server batch if it wants too doesn't seem to have a downside.
+*   Lee: at some point you get into the realm of trying to predict the future - and that's when you know you're getting into trouble!
+*   Lee: I know there's some databases that support chunked streaming.
+*   Lee: if our backend wants to give us 100 results 10 at a time we should send them 10 at a time to the client - certainly not 1 at a time.
+*   Jafar: so we definitely want to standardise a batch format.
+*   We don't have a batch format in Facebook right now, it's not been a significant issue for us though we have had some performance issues.
+*   Kewei: we've not had a global debounce on the server side that factors in everything, we only have it for stream which just uses the chunking from the backend
+*   It's an async iterator.
+*   Jafar: so we don't currently have a batch format
+*   Kewei: correct.
+*   Jafar: so I'm leaning towards [adding a batch format] - does anyone have opinions?
+*   Lee: subscriptions does not have a batch format - maybe it should? We should investiage if we can re-use the stream details from subscriptions for defer/stream. Batch might be a case that ends up being useful in both cases.
+*   Evan: "last update wins" - we debounce and throw away intermediate responses
+*   Jafar: this is for stream where we're returning all the records rather than subscriptions-style "last update wins"
+*   Lee: subscriptions are designed for realtime data, defer/stream are not.
+*   Jafar: one thing that might make it useful for the client to indicate is the page size - I might opt to tell the server to send batches that correspond to page sizes (based on the size of the screen). I'm reaching here
+*   Lee: I don't think you are, there's historical precedent here. Facebooks News Feed hacks together a bunch of this and a lot of science went into this to figure out the optimal batch sizes. We learned that "3" was the magic number - because there's always space to render 3 feed items.
+*   My first argument for @stream actually had an argument where you could specify the page sizes.
+*   Evan: smooth scroller on Android works well for page sized chunks
+*   Jafar: we control a lot of these values on the server side for configuration. We've converged on a server-side configuration model - because data delivery is hard to get right, so we wanted to take the decisions out of the GraphQL query so we can change them without updating the apps.
+*   Kewei: to add more context, a lot of the time you cannot find a static value that's always correct - it might be 2 around peak time to render a minimal amount of stories to everyone, but non-peak you might want to return batches of 10 because the servers are under less load.
+*   Jafar: to summarise: before we add things to the directives, we should figure out if we can find ways to associate directives with a label (or another approach we've done is to rewrite GraphQL parameters on the server side) - the headlines is that there's terrific benefits in the client specifying WHAT data, but there's terrific benefits in letting the server decide HOW to deliver the data.
+*   Lee: treating @stream/@defer as hints seem to be emerging as the right way to do this - it allows for both smart and naive servers.
+*   Jafar: adding labels to any directive that influences HOW data is delivered, then you can associate configurations on the server side with these labels. This suggests that WHAT / HOW is a good separation - arguments change WHAT, directives control HOW. (This isn't what we do currently, but maybe we should.) This may not work so well for open APIs like GitHubs vs closed like Facebook.
+*   We can also hint to the server which parameters can be overridden.
+*   Rob / Liliana: we agree it should be a hint; we've worked on an implementation in GraphQL.js where if it's not a promise we shouldn't even attempt to defer. For batching it's pretty easy to implement.
+*   Jafar: `@defer(enabled: $var)` allows the client to turn it on/off. Lets the server do experimentation by toggling the variables. Makes it so the server can decide to ignore @defer.
+*   Rob: we found having an `if` on `@defer` was useful - on the server we don't want @defer but on the client we do - better for SSR.
+*   Lee: to summarise: "stream and defer likely need some arguments (we're not sure how many yet); notably "if" which toggles it on/off, also an opaque label, maybe a chunk size". We also need to figure out a batching model.
+*   ACTION - Kewei - "chunk iterable" at Facebook - can you talk about that outside of the context of Hack?
+*   Lee: did I miss anything?
+*   Liliana - we want defer independent of its arguments to act like a hint.
+*   Lee: yeah, absolutely! It could be the entire thing is a hint, or each of the arguments are also hints.
+*   Kewei: we want to introduce these variables, but we don't want to detail in the spec that this will guarantee anything.
+*   Lee: the general rule of the server being able to override seems important, but we're not sure of the specifics of this yet. Clients have to opt in, but server can opt-out.
+*   ACTION - Jafar - explore a strawman around this regarding client versus server control
+*   Kewei: one more missing piece - should we try and specify the batch format?
+*   Lee: I suggest you look at how subscription streams are specified in the spec (they don't rely on JS or JSON or iterables, they're very abstract) and the goal would be to write something equivalently extract that handles all the scenarios that we need it to handle. The spec is 20% details and 80% examples. Describing the chunked iterable in spec terms instead of Hack terms could be a really good first step.
+*   ACTION - Kewei - have a look at how to describe chunked iterable in a more language agnostic way.
+*   Jafar - it might be that we just need a different payload format.
+*   Lee - agreed, let's abstract it down and figure out how much of it needs to be in there vs not.
+*   Kewei - I think it'd be good to have a small sub-workgroup on this to discuss before the next working group.
+*   ACTION - Jafar - post issue for people to stay involved/have a break-out session
+
+
+### Any other business
+
+**Action**: Lee to add recording to agenda template (both so we remember and for legal consent purposes)?
+


### PR DESCRIPTION
I've converted the meeting minutes from Google Docs to markdown.

For what it's worth, I'm using the "Docs to Markdown" Gsuite app, and getting accurate results.

Signed-off-by: Brian Warner <brian@bdwarner.com>