### PR TITLE
Add Matt Farmer to 2020-04-02 agenda

### DIFF
--- a/agendas/2020-04-02.md
+++ b/agendas/2020-04-02.md
@@ -28,6 +28,7 @@ agenda, edit this file.*
 | Name                     | Organization / Project   | Location
 | ------------------------ | ------------------------ | ------------------------
 | Lee Byron                | GraphQL Foundation       | San Francisco, CA, US
+| Matt Farmer              | Individual Contrib       | Oakland, CA, US
 | Evan Huus                | Shopify                  | Ottawa, ON, CA
 | Benjie Gillam ✏          | Graphile                 | Southampton, UK
 | Matt Mahoney             | Facebook                 | New York, NY, US
@@ -62,7 +63,7 @@ Example agenda item:
 1. Review previous meeting's action items (5m, Lee)
    - [Currently open action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22)
 1. Custom scalar specification URIs (5m, Evan Huus / Matt Farmer)
-   - Status check, still waiting on graphql-js?
+   - Status check, still waiting on graphql-js
 1. Input union RFC (5m, Evan Huus / Vince Foley)
    - We said we'd have a working session with the champions but couldn't schedule something. Do we want to try again or find a different process?
 1. `application/graphql` media type status (10m, Benjie)


### PR DESCRIPTION
I would like to attend and follow any updates on the "Custom scalar specification URIs" but will likely need to be on mute the majority of the meeting.

@eapache do you feel comfortable leading this topic this week?

I think most of these updates are probably more `graphql-js` specific and probably not the right audience for the `graphql-wg`, but my summary of the state of things is:
- Primarily waiting on @IvanGoncharov's input.  I left [this comment](https://github.com/graphql/graphql-js/pull/2276#issuecomment-604747470) last week, but haven't heard back.
- https://github.com/graphql/graphql-js/commit/a8f73dbfe0f76ff4eec4829a1426019a6df25eb2 was added to `master` in this morning which causes minor conflicts, but those have resolved locally and can be pushed up
- @IvanGoncharov had [asked a question on the tests](https://github.com/graphql/graphql-js/pull/2276#discussion_r388254710) on March 5th, which I responded to with some options, but still waiting on response there.
- That test is actually testing this part of [`src/utilities/extendSchema.js`](https://github.com/graphql/graphql-js/pull/2276#discussion_r387390296), which was the one area that I had a nit-pick question about any preference on an implementation detail.  There are 3 functionally equivalent options there, but open to other suggestions there as well. 