### PR TITLE
Add Matt Farmer to 2020-05-07 agenda

### DIFF
--- a/agendas/2020-05-07.md
+++ b/agendas/2020-05-07.md
@@ -27,6 +27,7 @@ agenda, edit this file.*
 | Name                     | Organization / Project   | Location
 | ------------------------ | ------------------------ | ------------------------
 | Lee Byron                | GraphQL Foundation       | San Francisco, CA, US
+| Matt Farmer              | Individual Contrib       | Oakland, CA, US
 | Benjie Gillam ✏️          | Graphile                 | Southampton, UK
 | Wojciech Trocki          | IBM/Red Hat              | Dublin
 | Terrence Howard          | Individual Contrib       | Washington DC, US
@@ -68,4 +69,6 @@ Example agenda item:
 1. Discuss RFC adding introspection shortcuts to determine full typename and named type’s name (15m, Terrence)
    - [#710 - Add namedType and punctuatedName to __Type](https://github.com/graphql/graphql-spec/pull/710)
 1. [Input Union RFC](https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md)
+1. Custom scalar specification URIs (5m, Evan Huus / Matt Farmer)
+   - Anticipate the [reference implementation PR](https://github.com/graphql/graphql-js/pull/2276#issuecomment-624593856) being merged soon.
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
SpecifiedBy is still/getting close!

If possible, it would be great if this could be covered at some point in the first 90 minutes, otherwise I may have to drop early.