### PR TITLE
Add Zoom password, update calendar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Pacific US time. Check the [`agendas/`](./agendas) for the exact date and time
 of upcoming meetings.
 
 Keep track of future upcoming meetings by subscribing to the
-[google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com)
-or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics) (maintained in UTC because time zones are hard).
+[Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). (maintained in UTC because time zones are hard).
 
 ### Joining a meeting?
 

--- a/agendas/2019-12-05.md
+++ b/agendas/2019-12-05.md
@@ -7,8 +7,9 @@ anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1uN1e22_4YEdPw-Gpt52J4fblSU5KmHz3vwqgMz89D8c/edit#heading=h.p1whx46b3fks
-- **Date & Time**: [December 5th 2019 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=12&day=5&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [December 5th 2019 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=12&day=5&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 

--- a/agendas/2020-01-09.md
+++ b/agendas/2020-01-09.md
@@ -7,8 +7,9 @@ anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/16nw4jFViPUjpo3mQZM-0b2MzFreZpb62nRZqsAzkFAI/edit?usp=sharing
-- **Date & Time**: [January 9th 2020 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=1&day=9&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [January 9th 2020 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=1&day=9&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 

--- a/agendas/2020-02-06.md
+++ b/agendas/2020-02-06.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [February 6th 2020 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=2&day=6&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [February 6th 2020 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=2&day=6&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1T7WVApYq9CJlZHKQa8FUaZ5HMeI3upTVPVJef3JrpKI/edit?usp=sharing
 
 

--- a/agendas/2020-03-05.md
+++ b/agendas/2020-03-05.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [March 5th 2020 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=3&day=5&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [March 5th 2020 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=3&day=5&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1DG9DwgqYi0OJQ4ahv9lIpKKgxTQh-rdxAu-EEcmmuC8/edit?usp=sharing
 
 

--- a/agendas/2020-04-02.md
+++ b/agendas/2020-04-02.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [April 2nd 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=4&day=2&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [April 2nd 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=4&day=2&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1IElYaroab82It4yJ5cMc9hEZm7HNk1wabufX0YNMOZg/edit?usp=sharing
 
 

--- a/agendas/2020-05-07.md
+++ b/agendas/2020-05-07.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [May 7th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=5&day=7&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [May 7th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=5&day=7&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1yk5RMGlTqDm0W900JqFp0TrnoDb3lgkVDR8sy0_-TuI/edit?usp=sharing
 
 

--- a/agendas/2020-06-04.md
+++ b/agendas/2020-06-04.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: TBD
 
 

--- a/agendas/2020-07-02.md
+++ b/agendas/2020-07-02.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [July 2nd 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=7&day=2&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: TBD
 
 

--- a/agendas/2020-08-06.md
+++ b/agendas/2020-08-06.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [August 6th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=8&day=6&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: TBD
 
 

--- a/agendas/2020-09-03.md
+++ b/agendas/2020-09-03.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [September 3rd 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=9&day=3&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: TBD
 
 

--- a/agendas/2020-10-01.md
+++ b/agendas/2020-10-01.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [October 1st 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=10&day=1&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: TBD
 
 

--- a/agendas/2020-11-05.md
+++ b/agendas/2020-11-05.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [November 5th 2020 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=11&day=5&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: TBD
 
 

--- a/agendas/2020-12-03.md
+++ b/agendas/2020-12-03.md
@@ -6,10 +6,11 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [December 3rd 2020 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=12&day=3&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), subscribe to the [google calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com) or [ical file](https://calendar.google.com/calendar/ical/graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com/public/basic.ics).
+- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740
+  - Password: graphqlwg
 - **Live Notes**: TBD
 
 


### PR DESCRIPTION
As discussed in the WG meeting last week, the Zoom now has a password.  I've also consolidated the meetings onto one calendar, so that we can more easily manage who is using the Zoom account when.

Signed-off-by: Brian Warner <brian@bdwarner.com>