### PR TITLE
Moving June 4th meeting to June 11th

### DIFF
--- a/agendas/2020-06-04.md
+++ b/agendas/2020-06-04.md
@@ -6,7 +6,7 @@ relevant topics to core GraphQL projects. This is an open meeting in which
 anyone in the GraphQL community may attend. *To attend this meeting or propose
 agenda, edit this file.*
 
-- **Date & Time**: [June 4th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=4&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
+- **Date & Time**: [June 11th 2020 16:00 - 19:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2020&month=6&day=11&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), view the [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 - **Video Conference Link**: https://zoom.us/j/593263740


### PR DESCRIPTION
Sorry for the short-notice date move.

It’s a crazy week in the world, crazier than our new normal. I hope everyone in the working group is doing okay. I'm postponing this month's working group meeting. I don't know if next week will be any less stressful than this one, but I can only hope for the best. I know I could personally use a bit of time to collect some calm and focus so I can bring my best for this next meeting.