### PR TITLE
Add Jesse Rosenberger to 2020-06-11 agenda.

### DIFF
--- a/agendas/2020-06-11.md
+++ b/agendas/2020-06-11.md
@@ -39,6 +39,7 @@ agenda, edit this file.*
 | Vince Foley              | New Relic / Absinthe     | Portland, OR, US
 | Evan Huus                | Shopify                  | Ottawa, ON, CA
 | Andrew Sprouse           | TakeShape                | Brooklyn, NY, US
+| Jesse Rosenberger        | Apollo                   | Helsinki, FI
 | Gabriel McAdams          |                          | San Jose, CA, US
 
 


### PR DESCRIPTION
I don't quite know what the policy is for ordering of attendee names in this list.  I thought at one point it was roughly _alphabetically by company after individual contributors and foundation members_, but not sure what the best pattern is anymore and not sure who individual contributors are / felt weird putting myself at the top of the list. 😄 

Therefore, I'm going for _least likely chance of a GitHub merge conflict based on existing PRs for the same file that are currently open_.
