### PR TITLE
Add links to working group video recordings

### DIFF
--- a/agendas/2019-11-07.md
+++ b/agendas/2019-11-07.md
@@ -8,6 +8,7 @@ community may attend, provided they first sign the [Specification Membership Agr
 - **Video Conference Link**: https://zoom.us/j/593263740
 - **Live Notes**: https://docs.google.com/document/d/1VzPzZEt92zxXDk63rHLradQtN2Yzs_LPISzvwwS6R2c/edit?usp=sharing
 - **Date & Time**: [November 7th 2019 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=11&day=7&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), [Subscribe to Google Calendar](https://calendar.google.com/calendar/embed?src=graphql.org_lc7llu5kovorb7dl1uo7c6h4ls%40group.calendar.google.com)
+- **Video Recording**: https://www.youtube.com/watch?v=fbcTVULqm-8
 
 <small>*NOTE:* Meeting date and time may change up to a week before the meeting.
 Please check the agenda the week of the meeting to confirm.</small>

--- a/agendas/2019-12-05.md
+++ b/agendas/2019-12-05.md
@@ -10,6 +10,7 @@ agenda, edit this file.*
   - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1uN1e22_4YEdPw-Gpt52J4fblSU5KmHz3vwqgMz89D8c/edit#heading=h.p1whx46b3fks
 - **Date & Time**: [December 5th 2019 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=12&day=5&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152), or subscribe ([Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t), [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics)).
+- **Video Recording**: https://www.youtube.com/watch?v=XzEHLpMq13A
 
   <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
 

--- a/agendas/2020-02-06.md
+++ b/agendas/2020-02-06.md
@@ -12,6 +12,7 @@ agenda, edit this file.*
 - **Video Conference Link**: https://zoom.us/j/593263740
   - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1T7WVApYq9CJlZHKQa8FUaZ5HMeI3upTVPVJef3JrpKI/edit?usp=sharing
+- **Video Recording**: https://www.youtube.com/watch?v=a0xwVVhH6rI
 
 
 ## Attendees

--- a/agendas/2020-03-05.md
+++ b/agendas/2020-03-05.md
@@ -12,6 +12,7 @@ agenda, edit this file.*
 - **Video Conference Link**: https://zoom.us/j/593263740
   - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1DG9DwgqYi0OJQ4ahv9lIpKKgxTQh-rdxAu-EEcmmuC8/edit?usp=sharing
+- **Video Recording**: https://www.youtube.com/watch?v=aezw-RYYDwY
 
 
 ## Attendees

--- a/agendas/2020-04-02.md
+++ b/agendas/2020-04-02.md
@@ -12,6 +12,7 @@ agenda, edit this file.*
 - **Video Conference Link**: https://zoom.us/j/593263740
   - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1IElYaroab82It4yJ5cMc9hEZm7HNk1wabufX0YNMOZg/edit?usp=sharing
+- **Video Recording**: https://www.youtube.com/watch?v=bCXQsfIgTng
 
 
 ## Attendees

--- a/agendas/2020-05-07.md
+++ b/agendas/2020-05-07.md
@@ -12,6 +12,7 @@ agenda, edit this file.*
 - **Video Conference Link**: https://zoom.us/j/593263740
   - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1yk5RMGlTqDm0W900JqFp0TrnoDb3lgkVDR8sy0_-TuI/edit?usp=sharing
+- **Video Recording**: https://www.youtube.com/watch?v=xtdcaOzoacU
 
 
 ## Attendees

--- a/agendas/2020-06-11.md
+++ b/agendas/2020-06-11.md
@@ -12,6 +12,7 @@ agenda, edit this file.*
 - **Video Conference Link**: https://zoom.us/j/593263740
   - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1spo9sRYOv1KOo1SBP0EObuWq_Qp0CvnyFmWHcdqEutU/edit?usp=sharing
+- **Video Recording**: https://www.youtube.com/watch?v=936z41Mo1tQ
 
 
 ## Attendees

--- a/agendas/2020-07-02.md
+++ b/agendas/2020-07-02.md
@@ -12,6 +12,7 @@ agenda, edit this file.*
 - **Video Conference Link**: https://zoom.us/j/593263740
   - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1vw5zEOHVPBtspoWRVQ279NSo_JfWg7ZEdGKix4O-nco/edit?usp=sharing
+- **Video Recording**: https://www.youtube.com/watch?v=1eGY7Rti-l8
 
 
 ## Attendees

--- a/agendas/2020-08-06.md
+++ b/agendas/2020-08-06.md
@@ -12,6 +12,7 @@ agenda, edit this file.*
 - **Video Conference Link**: https://zoom.us/j/593263740
   - Password: graphqlwg
 - **Live Notes**: https://docs.google.com/document/d/1_jvxzCkI6VWo2KEobisoiW1n_irJ4dp0aD8Pq9UXuvw/edit?usp=sharing
+- **Video Recording**: https://www.youtube.com/watch?v=FYF15RA9H3k
 
 
 ## Attendees

--- a/notes/2019-11-07.md
+++ b/notes/2019-11-07.md
@@ -1,5 +1,7 @@
 # GraphQL WG Meeting Notes for 2019/11/07
 
+Video recording: https://www.youtube.com/watch?v=fbcTVULqm-8
+
 ## Opening of the meeting
 
 ## Introduction of attendees

--- a/notes/2019-12-05.md
+++ b/notes/2019-12-05.md
@@ -1,5 +1,7 @@
 # GraphQL WG Meeting Notes for 2019/12/05
 
+Video recording: https://www.youtube.com/watch?v=XzEHLpMq13A
+
 ## Agenda
 
 *   Introduction of attendees (5m, Lee)

--- a/notes/2020-02-06.md
+++ b/notes/2020-02-06.md
@@ -1,5 +1,6 @@
 # GraphQL WG Notes - Feb 2020
 
+Video recording: https://www.youtube.com/watch?v=a0xwVVhH6rI
 
 ## Agenda:
 

--- a/notes/2020-03-05.md
+++ b/notes/2020-03-05.md
@@ -1,5 +1,6 @@
 # GraphQL WG Notes - March 2020
 
+Video recording: https://www.youtube.com/watch?v=aezw-RYYDwY
 
 ### Agenda
 

--- a/notes/2020-04-02.md
+++ b/notes/2020-04-02.md
@@ -1,5 +1,6 @@
-
 # GraphQL WG Notes - April 2020
+
+Video recording: https://www.youtube.com/watch?v=bCXQsfIgTng
 
 ## Agenda
 

--- a/notes/2020-05-07.md
+++ b/notes/2020-05-07.md
@@ -1,5 +1,6 @@
 ## GraphQL WG Notes - May 2020
 
+Video recording: https://www.youtube.com/watch?v=xtdcaOzoacU
 
 ### Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Lee)
 

--- a/notes/2020-06-11.md
+++ b/notes/2020-06-11.md
@@ -1,5 +1,7 @@
 # GraphQL WG Notes 11th June 2020
 
+Video recording: https://www.youtube.com/watch?v=936z41Mo1tQ
+
 ## Agenda
 
 *   Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Lee)


### PR DESCRIPTION
Please also note that I believe the YouTube video titled "GraphQL Working Group - March 5, 2019" is actually for 2020. I've linked it from the 2020 agenda; someone with access should probably fix the video title:

https://www.youtube.com/watch?v=aezw-RYYDwY