### PR TITLE
Add query ambiguity topic to October 2020 WG

### DIFF
--- a/agendas/2020-10-01.md
+++ b/agendas/2020-10-01.md
@@ -59,7 +59,7 @@ Example agenda item:
 1. Review agenda (2m, Lee)
 1. Review previous meeting's action items (5m, Lee)
    - [All action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
-1. Query ambiguity: discussion of replacements terms (30m, Benjie)
+1. Query ambiguity: discussion of replacement terms (30m, Benjie)
    - [Spec edits/glossary graphql-spec#777](https://github.com/graphql/graphql-spec/pull/777)
    - [Original issue graphql-spec#715](https://github.com/graphql/graphql-spec/issues/715)
    - [Previous discussion - May 2020](https://github.com/graphql/graphql-wg/blob/master/notes/2020-05-07.md#query-a-query-query-query-query-ambiguity-10m-benjie)

--- a/agendas/2020-10-01.md
+++ b/agendas/2020-10-01.md
@@ -59,4 +59,8 @@ Example agenda item:
 1. Review agenda (2m, Lee)
 1. Review previous meeting's action items (5m, Lee)
    - [All action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
+1. Query ambiguity: discussion of replacements terms (30m, Benjie)
+   - [Spec edits/glossary graphql-spec#777](https://github.com/graphql/graphql-spec/pull/777)
+   - [Original issue graphql-spec#715](https://github.com/graphql/graphql-spec/issues/715)
+   - [Previous discussion - May 2020](https://github.com/graphql/graphql-wg/blob/master/notes/2020-05-07.md#query-a-query-query-query-query-ambiguity-10m-benjie)
 1. *ADD YOUR AGENDA ABOVE*

--- a/agendas/2020-10-01.md
+++ b/agendas/2020-10-01.md
@@ -59,8 +59,9 @@ Example agenda item:
 1. Review agenda (2m, Lee)
 1. Review previous meeting's action items (5m, Lee)
    - [All action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
-1. Query ambiguity: discussion of replacement terms (30m, Benjie)
+1. Query ambiguity: discussion of replacement terms (25m, Benjie)
    - [Spec edits/glossary graphql-spec#777](https://github.com/graphql/graphql-spec/pull/777)
    - [Original issue graphql-spec#715](https://github.com/graphql/graphql-spec/issues/715)
    - [Previous discussion - May 2020](https://github.com/graphql/graphql-wg/blob/master/notes/2020-05-07.md#query-a-query-query-query-query-ambiguity-10m-benjie)
+1. [`__typename` and subscriptions](https://github.com/graphql/graphql-spec/pull/776) (5m, Benjie)
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
There's a reasonable chance that I won't have stable internet on this date*; if so I'll try and give 24 hours notice and request that we move this topic to November's WG.

\* _moving house soon; and can't go to another location due to COVID-19_.