### PR TITLE
Fix typo in TSC document

### DIFF
--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -19,7 +19,7 @@ The GraphQL Specification hosts other projects, in addition to the main specific
 
 * [GraphQL](https://spec.graphql.org)
 * [GraphQL over HTTP](https://github.com/graphql/graphql-over-http)
-* [GraphQL Scalers](https://github.com/graphql/graphql-scalars)
+* [GraphQL Scalars](https://github.com/graphql/graphql-scalars)
 
 We also host implementations, which are licensed under MIT:
 


### PR DESCRIPTION
Since this is a new process, I highlight this [from the TSC document](https://github.com/graphql/graphql-wg/blob/master/GraphQL-TSC.md#making-changes-to-this-document):

> An exception is made for errata or to update meeting logistics. These may be landed immediately, provided all EasyCLA checks have passed.

i.e. anyone with merge rights can merge this.
