### PR TITLE
Add "__typename not valid at subscription root" to Dec 2020 WG

### DIFF
--- a/agendas/2020-12-03.md
+++ b/agendas/2020-12-03.md
@@ -63,4 +63,5 @@ Example agenda item:
 1. [RFC: Default value coercion](https://github.com/graphql/graphql-spec/pull/793) (20m, Benjie)
 1. [RFC: Schema coordinates](https://github.com/graphql/graphql-spec/pull/746) (10m, Mark)
    - To talk about `Foo.baz.bar` vs `Foo.baz(bar:)` ([by popular demand](https://github.com/graphql/graphql-spec/pull/746#discussion_r526365127))
+1. [RFC: \_\_typename is not valid at subscription root](https://github.com/graphql/graphql-spec/pull/776) (10m, Benjie)
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
[Spec changes](https://github.com/graphql/graphql-spec/pull/776) have been re-written based on feedback and [a JS implementation](https://github.com/graphql/graphql-js/pull/2861) now exists.