### PR TITLE
Agenda fixes for Jan 2021

### DIFF
--- a/agendas/2021-01-07.md
+++ b/agendas/2021-01-07.md
@@ -37,12 +37,10 @@ agenda, edit this file.*
 | Mark Larah ✏️             | Yelp                     | San Francisco, CA, US
 | Matt Mahoney             | Facebook                 | New York, NY, US
 | Andreas Marek            | GraphQL-Java/Atlassian   | Sydney, Australia
+| Morris Matsa             | IBM                      | Boston, US
 | Rob Richard              | 1stDibs                  | New York, NY, US
 | Dan Schafer              | Facebook                 | Menlo Park, CA, US
-| James Baxley             | Apollo                   | South Carolina, US
-| Mike Cohen               | Indeed.com               | Austin, TX
 | Michael Staib            | ChilliCream              | Zurich, CH
-| Morris Matsa             | IBM                      | Boston, US
 | Brian Warner             | The Linux Foundation     | Cleveland, OH
 | *ADD YOUR NAME ABOVE TO ATTEND*
 
@@ -65,7 +63,6 @@ Example agenda item:
 
 -->
 
-1. Update on GraphQL Specification membership documents
 1. Agree to Membership Agreement, Participation Guidelines and Code of Conduct (1m, Lee)
    - [Specification Membership Agreement](https://github.com/graphql/foundation)
    - [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
@@ -76,6 +73,7 @@ Example agenda item:
 1. Review previous meeting's action items (5m, Lee)
    - [All action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
    - Input Unions WG 7pm UTC (11am PST, 6am AEDT) on Thursday 21st Jan ([Details in Slack](https://graphql.slack.com/archives/CTECCMU57/p1608223711031900?thread_ts=1606562127.018400&cid=CTECCMU57))
+1. Update on GraphQL Specification membership documents (5m, Brian)
 1. Advancing no introspection at root of Subscription operation (10m, Benjie)
    - [Spec PR](https://github.com/graphql/graphql-spec/pull/776)
    - [GraphQL.js validation rule](https://github.com/graphql/graphql-js/pull/2861)
@@ -89,5 +87,5 @@ Example agenda item:
    - [Spec PR](https://github.com/graphql/graphql-spec/pull/742)
    - `initialCount` as required argument in `@stream` ([discussion](https://github.com/graphql/graphql-spec/pull/742#discussion_r527600716))
    - `LIST_FIELD` as new directive location? ([discussion](https://github.com/graphql/graphql-js/issues/2848#issuecomment-743051196))
-1. Alternative meeting time 
+1. Alternative meeting time (10m, Andi)
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
Removes duplicate attendees and puts attendees in alphabetical order by surname. Fixes inconsistencies in the agenda entries. _Does not_ reorder the agenda items to the actual order that we did them in the end (for that, see the notes).