### PR TITLE
Update links and info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GraphQL community, operated by the GraphQL Foundation.
 
 The GraphQL WG's primary purpose is to discuss and agree upon
 proposed additions to the [GraphQL Specification](https://github.com/graphql/graphql-spec)
-via the [RFC process](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md). Additionally, the group may discuss and collaborate on other
+via the [RFC process](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md). Additionally, the group may discuss and collaborate on other
 relevant technical topics concerning core GraphQL projects.
 
 Anyone in the public GraphQL community may attend a GraphQL WG meeting, provided

--- a/README.md
+++ b/README.md
@@ -109,3 +109,11 @@ of the core GraphQL community. The spec [contribution process](https://github.co
 requires considerable investment through multiple stages while meeting a
 demanding set of guiding principles. This can take a long time, and progress in
 each meeting can feel small. Don't give up!
+
+# Contributing to this repo
+
+This repository is managed by EasyCLA. Project participants must sign the free ([GraphQL Specification Membership agreement](https://preview-spec-membership.graphql.org) before making a contribution. You only need to do this one time, and it can be signed by [individual contributors](http://individual-spec-membership.graphql.org/) or their [employers](http://corporate-spec-membership.graphql.org/).
+
+To initiate the signature process please open a PR against this repo. The EasyCLA bot will block the merge if we still need a membership agreement from you.
+
+You can find [detailed information here](https://github.com/graphql/graphql-wg/tree/main/membership). If you have issues, please email [operations@graphql.org](mailto:operations@graphql.org).


### PR DESCRIPTION
This PR fixes a link which referred to the `master` branch on graphql-spec, and adds info on signing the spec membership agreement through EasyCLA.