### PR TITLE
Extend `__typename` at subscription root RFC discussion

### DIFF
--- a/agendas/2021-05-06.md
+++ b/agendas/2021-05-06.md
@@ -71,7 +71,9 @@ Example agenda item:
    - Status Update
    - Fields vs Input Objects
 1. [Glossary RFC](https://github.com/graphql/graphql-spec/pull/846) (15m, Benjie)
-1. [Advancing `__typename` not valid at subscription root RFC](https://github.com/graphql/graphql-spec/pull/776) (5m, Benjie)
-   - Ivan has approved [the GraphQL.js changes](https://github.com/graphql/graphql-js/pull/2861)
-   - Main question: have other implementors had a chance to look at this yet?
+1. [Advancing `__typename` not valid at subscription root RFC](https://github.com/graphql/graphql-spec/pull/776) (30m, Benjie)
+   - Ivan approved [the GraphQL.js changes](https://github.com/graphql/graphql-js/pull/2861)
+   - Have since updated the implementation to more closely mirror the spec.
+   - Potential validation oversight - @skip/@include; see related RFC: https://github.com/graphql/graphql-spec/pull/860
+   - Question: have other implementors had a chance to look at this yet?
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
Adds this problem outlined in https://github.com/graphql/graphql-spec/pull/860 to the discussion, allocates more time, notes the new implementation.