### PR TITLE
Move Benjie's May topics to June

### DIFF
--- a/agendas/2021-05-06.md
+++ b/agendas/2021-05-06.md
@@ -67,13 +67,4 @@ Example agenda item:
    - [Original RFC Issue](https://github.com/graphql/graphql-spec/issues/687)
    - [Spec PR](https://github.com/graphql/graphql-spec/pull/849)
    - [Pending Implementation PR](https://github.com/graphql/graphql-js/pull/2449)
-1. [`oneOf` RFC](https://github.com/graphql/graphql-spec/pull/825) (15m, Evan and Benjie)
-   - Status Update
-   - Fields vs Input Objects
-1. [Glossary RFC](https://github.com/graphql/graphql-spec/pull/846) (15m, Benjie)
-1. [Advancing `__typename` not valid at subscription root RFC](https://github.com/graphql/graphql-spec/pull/776) (30m, Benjie)
-   - Ivan approved [the GraphQL.js changes](https://github.com/graphql/graphql-js/pull/2861)
-   - Have since updated the implementation to more closely mirror the spec.
-   - Potential validation oversight - @skip/@include; see related RFC: https://github.com/graphql/graphql-spec/pull/860
-   - Question: have other implementors had a chance to look at this yet?
 1. *ADD YOUR AGENDA ABOVE*

--- a/agendas/2021-06-03.md
+++ b/agendas/2021-06-03.md
@@ -31,6 +31,7 @@ agenda, edit this file.*
 | Name                     | Organization / Project   | Location
 | ------------------------ | ------------------------ | ------------------------
 | Lee Byron                | GraphQL Foundation       | San Francisco, CA, US
+| Benjie Gillam ✏️          | Graphile                 | Southampton, UK
 | *ADD YOUR NAME ABOVE TO ATTEND*
 
 
@@ -61,4 +62,13 @@ Example agenda item:
 1. Review agenda (2m, Lee)
 1. Review previous meeting's action items (5m, Lee)
    - [All action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
+1. [`oneOf` RFC](https://github.com/graphql/graphql-spec/pull/825) (15m, Evan and Benjie)
+   - Status Update
+   - Fields vs Input Objects
+1. [Glossary RFC](https://github.com/graphql/graphql-spec/pull/846) (15m, Benjie)
+1. [Advancing `__typename` not valid at subscription root RFC](https://github.com/graphql/graphql-spec/pull/776) (30m, Benjie)
+   - Ivan approved [the GraphQL.js changes](https://github.com/graphql/graphql-js/pull/2861)
+   - Have since updated the implementation to more closely mirror the spec.
+   - Potential validation oversight - @skip/@include; see related RFC: https://github.com/graphql/graphql-spec/pull/860
+   - Question: have other implementors had a chance to look at this yet?
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
Personal reasons.

@eapache I've taken the liberty of moving your topic too since it relates to `@oneOf` - as the `@oneOf` champion I'd certainly like to be there (and coherent) for that discussion. I won't merge this without your approval.