### PR TITLE
Add Ivan to May2021 WG + agenda items

### DIFF
--- a/agendas/2021-05-13.md
+++ b/agendas/2021-05-13.md
@@ -45,6 +45,7 @@ agenda, edit this file.*
 | Jordan Eldredge          | Facebook                 | San Francisco, CA, US
 | Joseph Savona            | Facebook                 | New York, NY, US
 | Uri Goldshtein           | The Guild                | Tel Aviv, IL
+| Ivan Goncharov           | graphql-js               | Lviv, UA
 | *ADD YOUR NAME ABOVE TO ATTEND*
 
 
@@ -75,6 +76,8 @@ Example agenda item:
 1. Review agenda (2m, Lee)
 1. Review previous meeting's action items (5m, Lee)
    - [All action items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+label%3A%22Action+item+%3Aclapper%3A%22)
+1. Release plan for next version of GraphQL specification (10m, Lee)
+1. `graphql-js`: [Status update on the Typescript migration](https://github.com/graphql/graphql-js/issues/2860) and temporary feature freeze on unrelated changes (5m, Ivan, Uri)
 1. [Default Value Coercion RFC](https://github.com/graphql/graphql-spec/pull/793) (5m, Evan)
    - [Ticket](https://github.com/rmosolgo/graphql-ruby/issues/3248) and [Draft PR](https://github.com/rmosolgo/graphql-ruby/pull/3448) of a failed ruby implementation
 1. Full unicode support (15m, Lee, Andi)
@@ -91,5 +94,4 @@ Example agenda item:
    - Have since updated the implementation to more closely mirror the spec.
    - Potential validation oversight - @skip/@include; see related RFC: https://github.com/graphql/graphql-spec/pull/860
    - Question: have other implementors had a chance to look at this yet?
-1. [Status update on the Typescript migration](https://github.com/graphql/graphql-js/issues/2104)
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
@leebyron I think we need to release a plan for spec and graphql-js.
So I added agenda item about spec release plan, please feel free to change it.