### PR TITLE
TSC: Ivan as Apollo employee and James as ex-Apollo

### DIFF
--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -126,9 +126,9 @@ The current voting members of the GraphQL TSC are:
 | [Benjie Gillam](https://github.com/benjie)         | Graphile              | Nov 1, 2020 | Dec 31, 2021 |
 | [Brielle Harrison](https://github.com/nyteshade)   | PayPal                | Nov 1, 2020 | Dec 31, 2021 |
 | [Dan Schafer](https://github.com/dschafer)         | Facebook              | Nov 1, 2020 | Dec 31, 2022 |
-| [Ivan Goncharov](https://github.com/IvanGoncharov) | Self                  | Nov 1, 2020 | Dec 31, 2021 |
+| [Ivan Goncharov](https://github.com/IvanGoncharov) | Apollo                | Nov 1, 2020 | Dec 31, 2021 |
 | [Matt Mahoney](https://github.com/mjmahone)        | Facebook              | Nov 1, 2020 | Dec 31, 2021 |
-| [James Baxley](https://github.com/jbaxleyiii)      | Apollo GraphQL        | Nov 1, 2020 | Dec 31, 2021 |
+| [James Baxley](https://github.com/jbaxleyiii)      | ex-Apollo             | Nov 1, 2020 | Dec 31, 2021 |
 | [Nick Schrock](https://github.com/schrockn)        | Elementl              | Nov 1, 2020 | Dec 31, 2022 |
 | [Rob Zhu](https://github.com/robzhu)               | AWS                   | Nov 1, 2020 | Dec 31, 2022 |
 | [Sasha Solomon](https://github.com/sachee)         | Twitter               | Nov 1, 2020 | Dec 31, 2022 |


### PR DESCRIPTION
I changed my affiliation column to Apollo since I joined Apollo in Aug 2021.
I also changed James status to `ex-Apollo` since he left in Jan 2021: https://twitter.com/jbaxleyiii/status/1352743551352926219