### PR TITLE
Redefine quorum to allow all to vote

### DIFF
--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -153,7 +153,13 @@ To provide consistency TSC elections will begin in 2021 for the 2022 term. Prior
 | 2023 - 2024 | Nov 1, 2022      | Dec 1, 2022 | Jan 1, 2023 | Dec 31, 2024 |
 | 2024 - 2025 | Nov 1, 2023      | Dec 1, 2023 | Jan 1, 2024 | Dec 31, 2025 |
 
-### Voting process
+#### Resignation or removal of TSC members
+
+A TSC member may voluntarily resign at any time before the end of their term by notifying the TSC chair. A TSC member may also be involuntarily removed by a supermajority (2/3) vote by TSC members.
+
+After a TSC seat vacancy the remaining TSC will collect self-nominations and vote on a replacement representative to complete the term. The nomination period should be open for at least two weeks, after which a vote shall be held.
+
+## Voting process
 
 When something cannot be decided by consensus or a formal vote is required, the TSC will use a method appropriate to the situation:
 
@@ -162,24 +168,43 @@ When something cannot be decided by consensus or a formal vote is required, the 
 
 The ballots may be public or private depending upon the situation, but the aggregate results should always be published.
 
-#### Minimum threshold for votes
+### Defining a quorum of "attending" members
 
-Because we work in a distributed environment, the voting process must account for a range of time zones and schedules. A quorum of at least half (or supermajority when relevent) of the TSC voting members must cast a ballot in order for the vote to be valid. Once the voting threshold has been met, one of these two critera must be satisfied to conclude the vote:
+To balance preserving the voting ability of all TSC members with the desire for the voting process to remain efficient and avoid deadlocks, we define a valid quorum based on members' recent attendance of GraphQL Working Group meetings.
+
+A quorum is a majority (more than half, or 2/3 for a supermajority vote) of the TSC *attending members*. A quorum must cast a ballot in order for a vote to be valid.
+
+A TSC *attending member* is a member who has attended one of the previous three meetings. Should a TSC member miss three consecutive meetings, they will no longer be counted when determining quorum (but may still vote). A member starts counting towards quorum as of attending a meeting.
+
+### Voting process
+
+Because we work in a distributed environment, the voting process must account for a range of time zones and schedules. Once the threshold of a quorum has been met and a vote is valid, one of these two critera must be satisfied to conclude a vote:
 
 * A notice is sent via email that the vote will conclude in three business days, reminding those who haven't voted that they should do so. The vote will conclude at the end of this time.
-* The election results will not change if additional TSC members vote.
+* The election results would not change with the addition of another vote.
 
-#### Ensuring efficient votes
+Once a valid vote is concluded, the result is determined by the number of votes recieved at that time (as opposed to the total number of TSC members):
 
-A TSC member must attend two of the previous five meetings to be considered a "TSC voting member" and be eligible to vote. Should a TSC member miss three or more of the prior five meetings, they will no longer vote or be counted toward the total number of voting members. This is to ensure broad participation as well as to avoid voting deadlocks.
+* For a simple majority (or supermajority), the votes in favor must exceed half (or 2/3) of the total number of votes.
+* For the Condorcet method, all votes received at the time the vote is concluded are considered.
 
-A member may regain their voting status by attending two meetings and may participate in votes in the second meeting.
+TSC members are not required to vote. An abstention vote is not considered part of the total set of votes, nor towards a voting quorum.
 
-#### Resignation or removal of TSC members
+<details>
+<summary>Example</summary>
 
-A TSC member may voluntarily resign at any time before the end of their term by notifying the TSC chair. A TSC member may also be involuntarily removed by a supermajority (2/3) vote by eligible TSC voting members less any with a conflict of interest.
+Consider this scenario for a simple majority vote:
 
-After a TSC seat vacancy the remaining TSC will collect self-nominations and vote on a replacement representative to complete the term. The nomination period should be open for at least two weeks, after which a vote shall be held.
+* 6 of 11 TSC members are considered *attending* members by having attended one of the last three WG meetings.
+* Being a simple majority, more than half of this 6 must cast votes to consider the vote valid. 4 votes are cast, so the vote is valid.
+* An email is sent out reminding more members to cast a vote within three business days.
+* 1 additional TSC *attending* member casts a vote.
+* 2 members who are not considered an *attending* member also cast a vote.
+* Three days pass, the vote is concluded.
+* A total of 7 votes have been cast.
+* The votes in favor must exceed half of the 7 total votes.
+* At least 4 votes must be in favor for the vote to pass.
+</details>
 
 ## Policies and procedures
 
@@ -195,9 +220,9 @@ Pull requests against this document that do not conflict with the [Technical Cha
 * There are two approvals by TSC members (not including the author)
 * The PR has been open for at least 72 hours
 
-Pull requests that change governance of the TSC (excluding the charter) must be open for at least 14 days, unless consensus is reached in a meeting with quorum of TSC voting members.
+Pull requests that change governance of the TSC (excluding the charter) must be open for at least 14 days, unless consensus is reached in a meeting with quorum of TSC *attending* members.
 
-If consensus cannot be reached, a pull request may still be landed after a vote by the TSC voting members to override outstanding objections.
+If consensus cannot be reached, a pull request may still be landed after a vote by TSC members to override outstanding objections.
 
 An exception is made for errata or to update meeting logistics. These may be landed immediately, provided all EasyCLA checks have passed.
 

--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -193,10 +193,29 @@ Once a valid vote is concluded, the result is determined by the number of votes 
 TSC members are not required to vote. There are three ways an *attending* member may reply to choose not to vote, each with a different intent and impact on the voting process:
 
 * **Present:** A reply of "present" causes an *attending* member to count towards quorum, but does not count towards the number of votes. This has the practical impact of allowing progress towards reaching quorum while lowering the number of "yes" votes required for a motion to pass. A member may reply "present" if they support a motion reaching a result, but do not have a preference if it passes or fails.
-* **Absent/Abstain:** A reply of "abstention" causes an *attending* member to neither count towards quorum, nor towards the number of votes. This is implied for any absent *attending* member which does not reply to a vote. The has the practical impact of hindering progress towards reaching quorum. A member may reply "abstain" if they do not support a motion reaching either result.
+* **Absent/Abstain:** A reply of "abstention" causes an *attending* member to neither count towards quorum, nor towards the number of votes. This is implied for any absent *attending* member which does not reply to a vote. This has the practical impact of hindering progress towards reaching quorum. A member may reply "abstain" if they do not support a motion reaching either result.
 * **Recused:** A reply of "recusal" causes a member to not count as an *attending* member for the purposes of this vote. This has the practical impact of both lowering the number of *attending* members required to reach quorum, and the number of "yes" votes required for a motion to pass. A member may reply "recused" if they want to remove themselves to minimize their impact on a vote, often due to a conflict of interest.
 
 Note: Non-attending members do not count towards quorum, and should they not vote are effectively recused.
+
+### Voting procedure
+
+Bringing this all together, here's a step-by-step procedure for administering a TSC vote:
+
+1. Formally open a vote for a motion by opening a GitHub issue.
+   * Most votes are held publicly, for those held privately, open an issue in a private forum.
+1. Take attendence of all TSC members over the prior three meetings to determine *attending members*.
+   * If a vote is raised during a meeting, count the live meeting as the most recent of the three.
+1. Determine the *quorum threshold* as the next number larger than half of *attending members*, or 2/3 for a supermajority.
+   * Examples: For 8 attending, a quorum threshold is 5. For 11 attending, quorum threshold is 6. For 9 attending, a supermajority quorum threshold is 7.
+1. Gather votes from *all members* until the number of votes from *attending members* reaches *quorum threshold*.
+   * A reply of "present" or "recused" may require recalculating *attending members* and/or *quorum threshold*.
+   * Send recurring reminders to remaining *attending members*.
+1. Message that the vote will be closed in 3 business days, make good faith attempt at reaching out to all remaining members.
+   * Conclude the vote early if, for single-winner votes, 6 *yes votes* or 5 *no votes* are received for a majority vote, or 8 *yes votes* or 3 *no votes* for a supermajority, as no additional set of votes could change the outcome.
+   * Any "present" or "recused" replies lower the thresholds for early conclusion.
+1. The resulting motion passes if the number of *yes votes* is a majority (or 2/3 supermajority) of *vote count*.
+1. Should a vote take place in a private forum, post the result in a public forum.
 
 <details>
 <summary>Example</summary>

--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -139,7 +139,7 @@ The [Technical Charter](https://github.com/graphql/foundation/blob/master/GraphQ
 
 ### Election process
 
-After November 1st, the TSC will collect self-nominations from the community. After December 1st, the TSC members who are not up for election will vote on the candidates using a multiple-winner method. The elected TSC members will begin their term on January 1st.
+After November 1st, the TSC will collect self-nominations from the community. After December 1st, the TSC members with terms not up for election will vote on the candidates using a multiple-winner method, members with expiring terms are recused from this vote due to conflict of interest. The elected TSC members will begin their term on January 1st.
 
 #### Initial period
 
@@ -176,6 +176,8 @@ A quorum is a majority (more than half, or 2/3 for a supermajority vote) of the 
 
 A TSC *attending member* is a member who has attended one of the previous three meetings. Should a TSC member miss three consecutive meetings, they will no longer be counted when determining quorum (but may still vote). A member starts counting towards quorum as of attending a meeting.
 
+Note: A member may be recused (i.e. for a member election) in which case they do not count as an *attending member* for the purpose of that vote.
+
 ### Voting process
 
 Because we work in a distributed environment, the voting process must account for a range of time zones and schedules. Once the threshold of a quorum has been met and a vote is valid, one of these two critera must be satisfied to conclude a vote:
@@ -185,8 +187,8 @@ Because we work in a distributed environment, the voting process must account fo
 
 Once a valid vote is concluded, the result is determined by the number of votes received at that time (as opposed to the total number of TSC members):
 
-* For a simple majority (or supermajority), the votes in favor must exceed half (or 2/3) of the total number of votes.
-* For the Condorcet method, all votes received at the time the vote is concluded are considered.
+* For a single-winner simple majority (or supermajority), the votes in favor must exceed half (or 2/3) of the total number of votes.
+* For a multiple-winner method, all votes received at the time the vote is concluded are considered.
 
 ### Non-votes
 
@@ -204,21 +206,24 @@ Bringing this all together, here's a step-by-step procedure for administering a 
 
 1. Formally open a vote for a motion by opening a GitHub issue.
    * Most votes are held publicly, for those held privately, open an issue in a private forum.
-1. Take attendence of all TSC members over the prior three meetings to determine *attending members*.
+1. Take attendence of all TSC members over the prior three meetings to determine *attending members* minus any recused.
    * If a vote is raised during a meeting, count the live meeting as the most recent of the three.
+   * For an election vote, members with expiring terms are recused and not counted towards *attending members*.
 1. Determine the *quorum threshold* as the next number larger than half of *attending members*, or 2/3 for a supermajority.
    * Examples: For 8 attending, a quorum threshold is 5. For 11 attending, quorum threshold is 6. For 9 attending, a supermajority quorum threshold is 7.
-1. Gather votes from *all members* until the number of votes from *attending members* reaches *quorum threshold*.
-   * A reply of "present" or "recused" may require recalculating *attending members* and/or *quorum threshold*.
+1. Gather votes from *all non-recused members* until the number of votes from *attending members* reaches *quorum threshold*.
+   * A reply of "recused" requires recalculating *attending members* and *quorum threshold*.
+   * A reply of "abstain" or "recused" does not count towards *quorum threshold*.
    * Send recurring reminders to remaining *attending members*.
 1. Message that the vote will be closed in 3 business days, make good faith attempt at reaching out to all remaining members.
-   * Conclude the vote early if, for single-winner votes, 6 *yes votes* or 5 *no votes* are received for a majority vote, or 8 *yes votes* or 3 *no votes* for a supermajority, as no additional set of votes could change the outcome.
-   * Any "present" or "recused" replies lower the thresholds for early conclusion.
+   * Conclude the vote early if no additional set of votes could change the outcome: e.g. for single-winner votes, 6 *yes votes* or 5 *no votes* are received for a majority vote, or 8 *yes votes* or 3 *no votes* for a supermajority.
+   * Any "non-vote" replies lower the thresholds for early conclusion.
 1. The resulting motion passes if the number of *yes votes* is a majority (or 2/3 supermajority) of *vote count*.
+   * For a multiple-winner vote, the stack-ranked votes are prepared and fed to a multiple-winner algorithm.
 1. Should a vote take place in a private forum, post the result in a public forum.
 
 <details>
-<summary>Example</summary>
+<summary>Typical example</summary>
 
 Consider this scenario for a simple majority vote:
 
@@ -232,6 +237,24 @@ Consider this scenario for a simple majority vote:
 * A total of 8 votes have been cast.
 * The votes in favor must exceed half of the 8 total votes.
 * There must be at least 5 "yes" votes for the motion to pass.
+</details>
+
+<details>
+<summary>Election example</summary>
+
+Consider this scenario for a member election:
+
+* 6 of 11 TSC members are considered *attending* members by having attended one of the last three WG meetings.
+* However, 2 of those members have expiring terms and are recused for the member election.
+* Thus 4 remain *attending* members for the purpose of this vote.
+* More than half of this 4 (thus, 3) must cast votes to reach quorum and consider the vote valid.
+* 3 votes by non-recused *attending* members are cast, reaching quorum. The vote's outcome will be valid.
+* An notice is sent out reminding all remaining non-recused members to cast a vote within three business days.
+* 1 additional TSC *attending* member casts a vote.
+* 1 non-attending member also casts a vote.
+* Three days pass, the vote is concluded.
+* A total of 5 votes have been cast.
+* The multiple-winner votes are input to a Condorcet algorithm to determine the outcome.
 </details>
 
 ## Policies and procedures

--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -157,7 +157,7 @@ To provide consistency TSC elections will begin in 2021 for the 2022 term. Prior
 
 A TSC member may voluntarily resign at any time before the end of their term by notifying the TSC chair. A TSC member may also be involuntarily removed by a supermajority (2/3) vote by TSC members.
 
-After a TSC seat vacancy the remaining TSC will collect self-nominations and vote on a replacement representative to complete the term. The nomination period should be open for at least two weeks, after which a vote shall be held.
+After a TSC seat vacancy the remaining TSC will collect self-nominations and vote on a replacement member to complete the term. The nomination period should be open for at least two weeks, after which a vote shall be held.
 
 ## Voting process
 
@@ -181,14 +181,22 @@ A TSC *attending member* is a member who has attended one of the previous three 
 Because we work in a distributed environment, the voting process must account for a range of time zones and schedules. Once the threshold of a quorum has been met and a vote is valid, one of these two critera must be satisfied to conclude a vote:
 
 * A notice is sent via email that the vote will conclude in three business days, reminding those who haven't voted that they should do so. The vote will conclude at the end of this time.
-* The election results would not change with the addition of another vote.
+* The election results would not change if all remaining members were to vote.
 
-Once a valid vote is concluded, the result is determined by the number of votes recieved at that time (as opposed to the total number of TSC members):
+Once a valid vote is concluded, the result is determined by the number of votes received at that time (as opposed to the total number of TSC members):
 
 * For a simple majority (or supermajority), the votes in favor must exceed half (or 2/3) of the total number of votes.
 * For the Condorcet method, all votes received at the time the vote is concluded are considered.
 
-TSC members are not required to vote. An abstention vote is not considered part of the total set of votes, nor towards a voting quorum.
+### Non-votes
+
+TSC members are not required to vote. There are three ways an *attending* member may reply to choose not to vote, each with a different intent and impact on the voting process:
+
+* **Present:** A reply of "present" causes an *attending* member to count towards quorum, but does not count towards the number of votes. This has the practical impact of allowing progress towards reaching quorum while lowering the number of "yes" votes required for a motion to pass. A member may reply "present" if they support a motion reaching a result, but do not have a preference if it passes or fails.
+* **Absent/Abstain:** A reply of "abstention" causes an *attending* member to neither count towards quorum, nor towards the number of votes. This is implied for any absent *attending* member which does not reply to a vote. The has the practical impact of hindering progress towards reaching quorum. A member may reply "abstain" if they do not support a motion reaching either result.
+* **Recused:** A reply of "recusal" causes a member to not count as an *attending* member for the purposes of this vote. This has the practical impact of both lowering the number of *attending* members required to reach quorum, and the number of "yes" votes required for a motion to pass. A member may reply "recused" if they want to remove themselves to minimize their impact on a vote, often due to a conflict of interest.
+
+Note: Non-attending members do not count towards quorum, and should they not vote are effectively recused.
 
 <details>
 <summary>Example</summary>
@@ -196,14 +204,15 @@ TSC members are not required to vote. An abstention vote is not considered part 
 Consider this scenario for a simple majority vote:
 
 * 6 of 11 TSC members are considered *attending* members by having attended one of the last three WG meetings.
-* Being a simple majority, more than half of this 6 must cast votes to consider the vote valid. 4 votes are cast, so the vote is valid.
-* An email is sent out reminding more members to cast a vote within three business days.
+* Being a simple majority, more than half of this 6 must cast votes to reach quorum and consider the vote valid.
+* 4 votes by *attending* members are cast, reaching quorum. The vote's outcome will be valid.
+* An notice is sent out reminding all remaining members to cast a vote within three business days.
 * 1 additional TSC *attending* member casts a vote.
-* 2 members who are not considered an *attending* member also cast a vote.
+* 3 non-attending members also cast a vote.
 * Three days pass, the vote is concluded.
-* A total of 7 votes have been cast.
-* The votes in favor must exceed half of the 7 total votes.
-* At least 4 votes must be in favor for the vote to pass.
+* A total of 8 votes have been cast.
+* The votes in favor must exceed half of the 8 total votes.
+* There must be at least 5 "yes" votes for the motion to pass.
 </details>
 
 ## Policies and procedures


### PR DESCRIPTION
This is an alternative proposal to https://github.com/graphql/graphql-wg/pull/818 which, while more complicated, is a better fit for the goals and principles, namely:

* All TSC members should have the capacity to vote, regardless of what we're voting on.
* TSC votes should remain efficient and resilient to any member not participating.

To do this, I'm proposing changing the way we vote by replacing the concept of a "voting member" with a "quorum":

* A "quorum" is the total number of votes needed for a vote to be considered valid, and this proposes defining that in a similar way we used to define voting members, but *simplifies this to "one of three" instead of "two of five"*.

* Removes the concept of a "voting member" - this means all members are always eligible to vote, even if they do not count towards quorum.