### PR TITLE
Add Benjie and security process (TSC Discussion) to January WG

### DIFF
--- a/agendas/2022/2022-01-06.md
+++ b/agendas/2022/2022-01-06.md
@@ -98,6 +98,14 @@ This is an open meeting in which anyone in the GraphQL community may attend.
 | Stephen Spalding   | @fotoetienne    | Netflix            | Los Gatos, CA, US
 | Ilya Solovyiov     | @ilslv          | juniper            | Minsk, Belarus, BY
 | Michael Staib.     | @michaelstaib   | ChilliCream        | Zurich, CH
+| Benjie Gillam      | @benjie         | Graphile           | Chandler's Ford, UK
+
+## TSC Agenda
+
+([TSC meetings are held at the beginning of the GraphQL WG meeting](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#tsc-meetings)).
+
+1. Define a process for reporting/dealing with security vulnerabilities (Benjie, 10m)
+   - [RFC](https://github.com/graphql/graphql-wg/issues/825)
 
 ## Agenda
 


### PR DESCRIPTION
@leebyron How would you like the TSC agenda added? I've put it in its own section which I believe makes sense, but if you want it mixed into the normal agenda let me know at which point to add it (I'd guess just before or just after the introduction of attendees?).

I may no longer be on the TSC by the time of this meeting (depending on the election results), but am happy to present this to the TSC or to let a TSC member do so nonetheless :+1: 