### PR TITLE
Add default value coercion to Jan 2022 WG

### DIFF
--- a/agendas/2022/2022-01-06.md
+++ b/agendas/2022/2022-01-06.md
@@ -127,6 +127,9 @@ This is an open meeting in which anyone in the GraphQL community may attend.
    - [RFC](https://github.com/graphql/graphql-wg/issues/825)
 1. Normative force of directives (15m, Yaacov)
    - [Spec clarification PR](https://github.com/graphql/graphql-spec/pull/908)
+1. Advancing Default Value Validation/Coercion (15m, Benjie)
+   - [Spec RFC](https://github.com/graphql/graphql-spec/pull/793)
+   - [GraphQL.js PR](https://github.com/graphql/graphql-js/pull/3049)
 1. Deprecation of input values (30m, Stephen)
    - [Spec PR](https://github.com/graphql/graphql-spec/pull/805)
    - [SHOULD or MUST](https://docs.google.com/document/d/1vw5zEOHVPBtspoWRVQ279NSo_JfWg7ZEdGKix4O-nco/edit#bookmark=id.ca80syw9ijhg)?


### PR DESCRIPTION
Default value coercion is currently stage 2.

To advance to stage 3 we need:

1. Consensus the solution is complete (via editor or working group)
2. Complete spec edits, including examples and prose
3. Compliant implementation in GraphQL.js (fully tested and merged or ready to merge)

I believe conditions 1 and 3 are satisfied - Lee stated in September:

> @graphql/implementers please take one last look at this stack of changes. I'm planning to clean this up and land soon, I'm pretty confident this is the right change. One last chance to give a compelling reason why not.
> -- https://github.com/graphql/graphql-js/pull/3049#issuecomment-911978734

I've just rewritten the algorithm in the spec to match Lee's implementation in GraphQL.js, so I believe this may be ready to go also (pending review).

