### PR TITLE
Proposal: GraphQL Composite Schemas Working Group

### DIFF
--- a/rfcs/CompositeSchemas.md
+++ b/rfcs/CompositeSchemas.md
@@ -22,8 +22,16 @@ It feels like it would be of benefit to the ecosystem at large if there were a s
 
 If this is of interest to you, please enter your name, GitHub handle, and organization below:
 
-| Name               | GitHub          | Organization       | Location
-| :----------------- | :-------------- | :----------------- | :-----------------
-| Benjie Gillam      | Benjie          | Graphile           | Chandler's Ford, UK
-| Michael Staib      | michaelstaib    | ChilliCream Inc.   | Zurich, CH
-| Matteo Collina     | mcollina        | NearForm           | Forlì, IT
+| Name              | GitHub        | Organization     | Location            |
+| :---------------- | :------------ | :--------------- | :------------------ |
+| Benjie Gillam     | @Benjie       | Graphile         | Chandler's Ford, UK |
+| Yaacov Rydzinski  | @yaacovCR     | Individual       | Neve Daniel, IL     |
+| Roman Ivantsov    | @rivantsov    | Microsoft        | Redmond, WA, US     |
+| Tim Suchanek      | @timsuchanek  | GraphCDN         | Berlin, DE          |
+| Saihajpreet Singh | @saihaj       | The Guild        | Ottawa, ON, CA      |
+| Matteo Collina    | @mcollina     | NearForm         | Forlì, IT           |
+| Uri Goldshtein    | @urigo        | The Guild        | Tel Aviv, IL        |
+| Marc-Andre Giroux | @xuorig       | Netflix          | Montreal, Canada    |
+| Praveen Durairaju | @praveenweb   | Hasura           | Bangalore, India    |
+| Hugh Willson      | @hwillson     | Apollo           | Ottawa, ON, CA      |
+| Michael Staib     | @michaelstaib | ChilliCream Inc. | Zurich, CH          |

--- a/rfcs/CompositeSchemas.md
+++ b/rfcs/CompositeSchemas.md
@@ -17,11 +17,7 @@ Though these are all separate solutions to similar problems, there are various c
 * Actually fetching the relevant data, and combining it to fulfil the GraphQL request
 * etc
 
-Not wanting to cause an [XKCD#927](https://xkcd.com/927/) situation…
-
-![XKCD 927](https://user-images.githubusercontent.com/129910/166689080-bc45979a-6e70-4d4f-9bcc-f8f3daea1ee6.png)
-
-… but, it feels like it would be of benefit to the ecosystem at large if there were a shared specification that covers a few of these needs.
+It feels like it would be of benefit to the ecosystem at large if there were a shared specification that covers a few of these needs.
 
 If this is of interest to you, please enter your name, GitHub handle, and organization below:
 

--- a/rfcs/CompositeSchemas.md
+++ b/rfcs/CompositeSchemas.md
@@ -1,0 +1,30 @@
+# RFC: GraphQL Composite Schemas
+
+There's a _lot_ of different ways of combining multiple GraphQL schemas together to form a larger composite schema, and the wide variety of options can make it challenging to design schemas in a way that will be easy to compose later. To name but a few approaches:
+
+* Schema merging and stitching (various implementations in many languages)
+* GraphQL modules and other "extend type"-based approaches
+* Federation (Apollo's v1 and v2, Mercurius, WunderGraph, Hot Chocolate, etc)
+* Hasura's GraphQL Joins
+
+Though these are all separate solutions to similar problems, there are various concerns that most of them have to consider:
+
+* Identifying the schemas to join
+* Discovering/defining the relationships between the types/schemas
+* Schema manipulation to avoid conflicts (e.g. renaming types/fields)
+* Declaring which schemas "own" a particular type, and detecting conflicts
+* Detecting breaking changes
+* Actually fetching the relevant data, and combining it to fulfil the GraphQL request
+* etc
+
+Not wanting to cause an [XKCD#927](https://xkcd.com/927/) situation…
+
+![XKCD 927](https://user-images.githubusercontent.com/129910/166689080-bc45979a-6e70-4d4f-9bcc-f8f3daea1ee6.png)
+
+… but, it feels like it would be of benefit to the ecosystem at large if there were a shared specification that covers a few of these needs.
+
+If this is of interest to you, please enter your name, GitHub handle, and organization below:
+
+| Name               | GitHub          | Organization       | Location
+| :----------------- | :-------------- | :----------------- | :-----------------
+| Benjie Gillam      | Benjie          | Graphile           | Chandler's Ford, UK

--- a/rfcs/CompositeSchemas.md
+++ b/rfcs/CompositeSchemas.md
@@ -25,3 +25,4 @@ If this is of interest to you, please enter your name, GitHub handle, and organi
 | :----------------- | :-------------- | :----------------- | :-----------------
 | Benjie Gillam      | Benjie          | Graphile           | Chandler's Ford, UK
 | Michael Staib      | michaelstaib    | ChilliCream Inc.   | Zurich, CH
+| Matteo Collina     | mcollina        | NearForm           | Forlì, IT

--- a/rfcs/CompositeSchemas.md
+++ b/rfcs/CompositeSchemas.md
@@ -2,20 +2,21 @@
 
 There's a _lot_ of different ways of combining multiple GraphQL schemas together to form a larger composite schema, and the wide variety of options can make it challenging to design schemas in a way that will be easy to compose later. To name but a few approaches:
 
-* Schema merging and stitching (various implementations in many languages)
-* GraphQL modules and other "extend type"-based approaches
-* Federation (Apollo's v1 and v2, Mercurius, WunderGraph, Hot Chocolate, etc)
-* Hasura's GraphQL Joins
+- Schema merging and stitching (various implementations in many languages)
+- GraphQL modules and other "extend type"-based approaches
+- Federation (Apollo's v1 and v2, Mercurius, WunderGraph, Hot Chocolate, etc)
+- Hasura's GraphQL Joins
 
 Though these are all separate solutions to similar problems, there are various concerns that most of them have to consider:
 
-* Identifying the schemas to join
-* Discovering/defining the relationships between the types/schemas
-* Schema manipulation to avoid conflicts (e.g. renaming types/fields)
-* Declaring which schemas "own" a particular type, and detecting conflicts
-* Detecting breaking changes
-* Actually fetching the relevant data, and combining it to fulfil the GraphQL request
-* etc
+- Identifying the schemas to join
+- Discovering/defining the relationships between the types/schemas
+- Schema manipulation to avoid conflicts (e.g. renaming types/fields)
+- Resolving questions around type "ownership", redundancy and/or sharing; detecting conflicts
+- Detecting breaking changes
+- Actually fetching the relevant data, and combining it to fulfil the GraphQL request
+- Managing composition metadata with respect to handling the above concerns
+- etc
 
 It feels like it would be of benefit to the ecosystem at large if there were a shared specification that covers a few of these needs.
 

--- a/rfcs/CompositeSchemas.md
+++ b/rfcs/CompositeSchemas.md
@@ -6,6 +6,7 @@ There's a _lot_ of different ways of combining multiple GraphQL schemas together
 - GraphQL modules and other "extend type"-based approaches
 - Federation (Apollo's v1 and v2, Mercurius, WunderGraph, Hot Chocolate, etc)
 - Hasura's GraphQL Joins
+- Atlassian's Nadel
 
 Though these are all separate solutions to similar problems, there are various concerns that most of them have to consider:
 

--- a/rfcs/CompositeSchemas.md
+++ b/rfcs/CompositeSchemas.md
@@ -24,3 +24,4 @@ If this is of interest to you, please enter your name, GitHub handle, and organi
 | Name               | GitHub          | Organization       | Location
 | :----------------- | :-------------- | :----------------- | :-----------------
 | Benjie Gillam      | Benjie          | Graphile           | Chandler's Ford, UK
+| Michael Staib      | michaelstaib    | ChilliCream Inc.   | Zurich, CH


### PR DESCRIPTION
There's a _lot_ of different ways of combining multiple GraphQL schemas together to form a larger composite schema, and the wide variety of options can make it challenging to design schemas in a way that will be easy to compose later. To name but a few approaches:

* Schema merging and stitching (various implementations in many languages)
* GraphQL modules and other "extend type"-based approaches
* Federation (Apollo's v1 and v2, Mercurius, WunderGraph, Hot Chocolate, etc)
* Hasura's GraphQL Joins

Though these are all separate solutions to similar problems, there are various concerns that most of them have to consider:

* Identifying the schemas to join
* Discovering/defining the relationships between the types/schemas
* Schema manipulation to avoid conflicts (e.g. renaming types/fields)
* Declaring which schemas "own" a particular type, and detecting conflicts
* Detecting breaking changes
* Actually fetching the relevant data, and combining it to fulfil the GraphQL request
* etc

Not wanting to cause an [XKCD#927](https://xkcd.com/927/) situation…

![XKCD 927](https://user-images.githubusercontent.com/129910/166689080-bc45979a-6e70-4d4f-9bcc-f8f3daea1ee6.png)

… but, it feels like it would be of benefit to the ecosystem at large if there were a shared specification that covers a few of these needs.

---

I propose we set up a working group encompassing people working on these problems and start some discussions around forming a common specification that covers a few of these needs.

I'm not suggesting that we aim to write a full specification for "The One True Way To Build A Big GraphQL Schema From A Number Of Smaller GraphQL Schemas" (TOTWTBABGSFANOSGS) ─ the different approaches listed above tend to solve slightly different problems and have different pros and cons for different situations. Instead, I propose a smaller specification that describes the common ground that everyone can build and innovate on top of. My hope is that this will help the entire ecosystem iterate more rapidly; and will also give GraphQL users more choice, enabling the best solutions for each given problem set to float to the surface more easily.

Initially, I think it would be great to get representatives from the various projects working in this space together to discuss what a spec might look like, and what it should contain. I propose the name "GraphQL Composite Schemas Working Group" to keep it as vendor neutral as possible.

If you're interested, comment below!