### PR TITLE
Add ndejaco2 for June working group meeting

### DIFF
--- a/agendas/2022/2022-06-02.md
+++ b/agendas/2022/2022-06-02.md
@@ -102,6 +102,7 @@ This is an open meeting in which anyone in the GraphQL community may attend.
 | Benjie Gillam ✏    | @benjie         | Graphile           | Chandler's Ford, UK
 | Bobbie Cochrane.   | @bobbiejc       | StepZen            | Oriental, NC
 | Yaacov Rydzinski   | @yaacovcr       | Individual         | Neve Daniel, IL
+| Nick DeJaco        | @ndejaco2       | Amazon             | Seattle, WA, US
 
 ## Agenda
 


### PR DESCRIPTION
Add ndejaco2 to attend June working group meeting representing Amazon (AppSync). 