### PR TITLE
Revise TSC meeting text w.r.t. WG meeting cadence

### DIFF
--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -183,7 +183,7 @@ To balance preserving the voting ability of all TSC members with the desire for 
 
 A quorum is a majority (more than half, or 2/3 for a supermajority vote) of the TSC *attending members*. A quorum must cast a ballot in order for a vote to be valid.
 
-A TSC *attending member* is a member who has attended a TSC meeting in the past 100 days. Should a TSC member not attend a TSC meeting for more than 100 days, they will no longer be counted when determining quorum (but may still vote). A member starts counting towards quorum as of attending a TSC meeting.
+A TSC *attending member* is a member who has attended a meeting in the past 100 days. Should a TSC member not attend a meeting for more than 100 days, they will no longer be counted when determining quorum (but may still vote). A member starts counting towards quorum as of attending a meeting.
 
 Note: A member may be recused (i.e. for a member election) in which case they do not count as an *attending member* for the purpose of that vote.
 

--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -37,7 +37,7 @@ Developers who are covered under a signed spec membership agreement are able to 
 
 ## TSC meetings
 
-The GraphQL TSC will meet monthly, at the beginning of the [GraphQL Working Group meeting](https://github.com/graphql/graphql-wg). Our goal is to meet regularly to address any agenda items quickly and openly. By combining the TSC meeting with the open attendance Working Group meetings, we are ensuring that the broader community has visibility into the operations of the TSC, and vice versa.
+The GraphQL TSC will meet monthly, at the beginning of the first [GraphQL Working Group meeting](https://github.com/graphql/graphql-wg) each month. Our goal is to meet regularly to address any agenda items quickly and openly. By combining the TSC meeting with the open attendance Working Group meetings, we are ensuring that the broader community has visibility into the operations of the TSC, and vice versa.
 
 To attend a GraphQL TSC meeting, you must follow the same process as other GraphQL meetings and open a PR to add your name to the list of attendees in the [meeting agenda](https://github.com/graphql/graphql-wg/tree/master/agendas). If you have not signed the GraphQL Specification Membership Agreement you will be prompted to do so. You cannot attend until you have completed this document, although you are welcome to listen to the replay on [YouTube](https://www.youtube.com/playlist?list=PLP1igyLx8foH30_sDnEZnxV_8pYW3SDtb).
 
@@ -183,7 +183,7 @@ To balance preserving the voting ability of all TSC members with the desire for 
 
 A quorum is a majority (more than half, or 2/3 for a supermajority vote) of the TSC *attending members*. A quorum must cast a ballot in order for a vote to be valid.
 
-A TSC *attending member* is a member who has attended one of the previous three meetings. Should a TSC member miss three consecutive meetings, they will no longer be counted when determining quorum (but may still vote). A member starts counting towards quorum as of attending a meeting.
+A TSC *attending member* is a member who has attended a TSC meeting in the past 100 days. Should a TSC member not attend a TSC meeting for more than 100 days, they will no longer be counted when determining quorum (but may still vote). A member starts counting towards quorum as of attending a TSC meeting.
 
 Note: A member may be recused (i.e. for a member election) in which case they do not count as an *attending member* for the purpose of that vote.
 


### PR DESCRIPTION
@mjmahone [raised](https://github.com/graphql/graphql-wg/discussions/1051#discussioncomment-3327735) that the new increased cadence of WG meetings would impact on the TSC document. This edit attempts to maintain roughly the current level of commitment expected of TSC members whilst allowing for the WG to meet more than once per month. Originally I was going to propose 90 days, but to allow for the fact that "the first Thursday" can move around a bit I figured 100 days would be a safer bet (96 seemed too pedantic...).

This is a change to the TSC document, so we must follow [the rules](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#making-changes-to-this-document). I think this has a material impact on the expectation of TSC members, so I think the following applies:

> Pull requests that change governance of the TSC (excluding the charter) must be open for at least 14 days, unless consensus is reached in a meeting with quorum of TSC attending members.
> If consensus cannot be reached, a pull request may still be landed after a vote by TSC members to override outstanding objections.