### PR TITLE
Updating the decision of the Input Union RFC to RFC #825 using @oneOf

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -1124,8 +1124,10 @@ A quick glance at the evaluation results. Remember that passing or failing a spe
 
 # ☑️ Decision Time!
 
-Following meetings of the GraphQL Input Unions working group, [Solution 7][solution-7] was
-proposed as an evolution of Solution 5, and is currently the leading solution.
+The end result of this RFC is the [RFC: OneOf Input Objects #825](https://github.com/graphql/graphql-spec/pull/825).
+
+~~Following meetings of the GraphQL Input Unions working group, [Solution 7][solution-7] was~~
+~~proposed as an evolution of Solution 5, and is currently the leading solution.~~
 
 ~~According to a simple [weight ranking](https://docs.google.com/spreadsheets/d/1ymKqI6BSTHGGHkf9IDjo0EJmOqMryS-uQRwDV77OF5g/edit?usp=sharing), here are the solutions in order:~~
 


### PR DESCRIPTION
## Problem
Through search, I kept coming up with this older Input Union RFC when searching for the natural term of "GraphQL Input Union".

I suspect this will be the most popular search term that those unfamiliar with the WG will try, and @oneOf does not meet that naturally at.  The first search result on google for me is https://github.com/graphql/graphql-spec/issues/488 - which points to this InputUnion file

## This Change

This change just updates the final decision to note the updated RFC for @oneOf which is currently undergoing active dev for inclusion into the release spec.
