### PR TITLE
Add TSC meeting cadence topic to Sept WG

### DIFF
--- a/agendas/2022/2022-09-01.md
+++ b/agendas/2022/2022-09-01.md
@@ -114,6 +114,7 @@ This is an open meeting in which anyone in the GraphQL community may attend.
    - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
    - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
    - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
+1. **TSC**: [Revise TSC meeting text w.r.t. WG meeting cadence](https://github.com/graphql/graphql-wg/pull/1098) (5m, Benjie)
 1. Specifying 'extensions' property on requests (10m, Benjie)
    - [RFC](https://github.com/graphql/graphql-spec/pull/976)
 1. Defer/Stream update (30m, Rob)


### PR DESCRIPTION
From [the TSC document](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#tsc-meetings):

> The GraphQL TSC will meet monthly, at the beginning of the [GraphQL Working Group meeting](https://github.com/graphql/graphql-wg). Our goal is to meet regularly to address any agenda items quickly and openly. By combining the TSC meeting with the open attendance Working Group meetings, we are ensuring that the broader community has visibility into the operations of the TSC, and vice versa.

Thus I've added this to the "beginning" of the meeting.