### PR TITLE
Implement new WG times + secondary meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-GraphQL Working Group
-=====================
+# GraphQL Working Group
 
-GraphQL WG (Working Group) is a monthly virtual meeting of maintainers of
-commonly used GraphQL libraries and tools and significant contributors to the
-GraphQL community, operated by the GraphQL Foundation.
+GraphQL WG (Working Group) is a set of recurring virtual meetings of maintainers
+of commonly used GraphQL libraries and tools and significant contributors to the
+GraphQL community hosted by the [GraphQL TSC][] as part of the [GraphQL Foundation][].
+
+[graphql tsc]: ./GraphQL-TSC.md
+[graphql foundation]: https://graphql.org/foundation/
 
 The GraphQL WG's primary purpose is to discuss and agree upon
 proposed additions to the [GraphQL Specification](https://github.com/graphql/graphql-spec)
@@ -15,17 +17,43 @@ they first sign the [Specification Membership Agreement](./membership) or belong
 
 This repository holds [agendas](./agendas) and [notes](./notes) for all meetings
 past and upcoming as well as [shared rfc documents](./rfcs). Anyone may edit an
-upcoming event's agenda to *attend* or *propose an agenda item*.
+upcoming event's agenda to _attend_ or _propose an agenda item_.
 
 All meetings occur via video conference, however participating company
 offices are welcome to host guests.
 
-Meetings are typically scheduled for the first Thursday of each month at 9:00am
-Pacific US time. Check the [agendas](./agendas) for the exact date and time
-of upcoming meetings.
+# Upcoming meetings
 
-Keep track of future upcoming meetings by subscribing to the
-[Google Calendar](https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) or [ical file](https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics). (maintained in UTC because time zones are hard).
+| Meeting              | Time                            | Host                                     |
+| -------------------- | ------------------------------- | ---------------------------------------- |
+| WG (Primary)         | 1st Thu, 10:30am - 12:00noon PT | [Lee Byron](https://github.com/leebyron) |
+| WG (Secondary, APAC) | 2nd Wed, 3:30pm - 5:00pm PT     | [Lee Byron](https://github.com/leebyron) |
+| WG (Secondary, EU)   | 3rd Thu, 10:30am - 12:00noon PT | [Lee Byron](https://github.com/leebyron) |
+
+The primary monthly meeting is preferred for new agenda. The secondary meetings
+are for overflow agenda items, follow ups from the primary meeting, or agenda
+introduced by those who could not make the primary meeting time. There are two
+secondary meetings, each timed to be acceptable for those in either an Asia
+Pacific or European timezone.
+
+Meetings are typically scheduled at the times listed, however always check
+the [agenda](./agendas) for the exact date and time of an upcoming meeting. Keep
+track of future upcoming meetings by subscribing to the [Google Calendar][] or [ical][].
+
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[ical]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
+
+### Subcommittee meetings
+
+The GraphQL WG has subcomittees who focus on the development of specific
+projects beyond the GraphQL Spec. These subcomittees make progress within their
+own meetings and report back progress and decisions to GraphQL WG meetings.
+
+| Subcommittee     | Time                          | Host                                               | Agenda Repo                                                                                       |
+| ---------------- | ----------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQL.js       | 4th Wed, 10:00am - 11:00am PT | [Ivan Goncharov](https://github.com/IvanGoncharov) | [graphql/graphql-js-wg](https://github.com/graphql/graphql-js-wg)                                 |
+| GraphQL HTTP     | 3rd Thu, 8:00am - 10:00am PT  | [Benjie Gillam](https://github.com/benjie)         | [graphql/graphql-over-http](https://github.com/graphql/graphql-over-http/tree/main/working-group) |
+| Composite Schema | 2nd Thu, 8:00am - 10:00am PT  | [Benjie Gillam](https://github.com/benjie)         | [graphql/composite-schemas-wg](https://github.com/graphql/composite-schemas-wg)                   |
 
 ### Joining a meeting?
 
@@ -46,7 +74,7 @@ follow or run off course. When we talk about issues we care about, it's easy to
 get into heated debate. In order to respect everyone's time, and arrive to
 worthwhile outcomes, consider a few guidelines:
 
-*These guidelines are heavily inspired by [Allen Wirfs-Brock](http://wirfs-brock.com/allen/files/papers/standpats-asianplop2016.pdf).*
+_These guidelines are heavily inspired by [Allen Wirfs-Brock](http://wirfs-brock.com/allen/files/papers/standpats-asianplop2016.pdf)._
 
 ### Participate
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ own meetings and report back progress and decisions to GraphQL WG meetings.
 
 | Subcommittee     | Time                          | Host                                               | Agenda Repo                                                                                       |
 | ---------------- | ----------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| GraphQL.js       | 4th Wed, 10:00am - 11:00am PT | [Ivan Goncharov](https://github.com/IvanGoncharov) | [graphql/graphql-js-wg](https://github.com/graphql/graphql-js-wg)                                 |
-| GraphQL HTTP     | 3rd Thu, 8:00am - 10:00am PT  | [Benjie Gillam](https://github.com/benjie)         | [graphql/graphql-over-http](https://github.com/graphql/graphql-over-http/tree/main/working-group) |
+| GraphiQL         | 2nd Tue, 9:00am - 11:00am PT  | [Tim Suchanek](https://github.com/timsuchanek)     | [graphql/graphiql/working-group](https://github.com/graphql/graphiql/tree/main/working-group)     |
 | Composite Schema | 2nd Thu, 8:00am - 10:00am PT  | [Benjie Gillam](https://github.com/benjie)         | [graphql/composite-schemas-wg](https://github.com/graphql/composite-schemas-wg)                   |
+| GraphQL HTTP     | 3rd Thu, 8:00am - 10:00am PT  | [Benjie Gillam](https://github.com/benjie)         | [graphql/graphql-over-http/working-group](https://github.com/graphql/graphql-over-http/tree/main/working-group) |
+| GraphQL.js       | 4th Wed, 10:00am - 11:00am PT | [Ivan Goncharov](https://github.com/IvanGoncharov) | [graphql/graphql-js-wg](https://github.com/graphql/graphql-js-wg)                                 |
 
 ### Joining a meeting?
 

--- a/agendas/2022/10-Oct/wg-primary.md
+++ b/agendas/2022/10-Oct/wg-primary.md
@@ -1,0 +1,113 @@
+<!--
+
+Hello! You're welcome to join our working group meeting and add to the agenda
+by following these three steps:
+
+   1. Add your name to the list of attendees (in alphabetical order).
+
+      - To respect meeting size, attendees should be relevant to the agenda.
+        That means we expect most who join the meeting to participate in
+        discussion. If you'd rather just watch, check out our YouTube[1].
+
+      - Please include the organization (or project) you represent, and the
+        location (including country code[2]) you expect to be located in during
+        the meeting.
+
+      - If you're willing to help take notes, add "✏️" after your name
+        (eg. Ada Lovelace ✏). This is hugely helpful!
+
+   2. If relevant, add your topic to the agenda (sorted by expected time).
+
+      - Every agenda item has four parts: 1) the topic, 2) an expected time
+        constraint, 3) who's leading the discussion, and 4) a list of any
+        relevant links (RFC docs, issues, PRs, presentations, etc). Follow the
+        format of existing agenda items.
+
+      - Know what you want to get out of the agenda topic - what feedback do you
+        need? What questions do you need answered? Are you looking for consensus
+        or just directional feedback?
+
+      - If your topic is a new proposal it's likely an "RFC 0"[3]. The barrier
+        of entry for documenting new proposals is intentionally low, writing a
+        few sentences about the problem you're trying to solve and the rough
+        shape of your proposed solution is normally sufficient.
+
+        You can create a link for this:
+          - As an issue against the graphql-wg repo.
+          - As a GitHub discussion in the graphql-wg repo.
+          - As an RFC document into the rfcs/ folder of the graphql-wg repo.
+
+   3. Review our guidelines and agree to our Spec Membership & CLA.
+
+      - Review and understand our Spec Membership Agreement, Participation &
+        Contribution Guidelines, and Code of Conduct. You'll find links to these
+        in the first agenda item of every meeting.
+
+      - If this is your first time, our bot will comment on your Pull Request
+        with a link to our Spec Membership & CLA. Please follow along and agree
+        before your PR is merged.
+
+        Your organization may sign this for all of its members. To set this up,
+        please ask operations@graphql.org.
+
+PLEASE TAKE NOTE:
+
+  - By joining this meeting you must agree to the Specification Membership
+    Agreement and Code of Conduct.
+
+  - Meetings are recorded and made available on YouTube[1], by joining you
+    consent to being recorded.
+
+[1] Youtube: https://www.youtube.com/channel/UCERcwLeheOXp_u61jEXxHMA
+[2] Country codes: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes
+[3] RFC stages: https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#rfc-contribution-stages
+
+-->
+
+| This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
+| ---------------------------------------------------------------------------------------- |
+
+# GraphQL WG – October 2022 (Primary)
+
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
+
+This is our primary monthly meeting, which typically meets on the first Thursday
+of the month. In the case we have additional agenda items or follow ups, we also
+hold additional secondary meetings later in the month.
+
+- **Date & Time**: [October 6th 2022 10:30am - 12:00noon PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221006T173000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+  - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
+  - _Please Note:_ The date or time may change. Please check this agenda the
+    week of the meeting to confirm. While we try to keep all calendars accurate,
+    this agenda document is the source of truth.
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
+
+[graphql specification]: https://github.com/graphql/graphql-spec
+[calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
+
+## Attendees
+
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
+
+## Agenda
+
+1. Agree to Membership Agreement, Participation & Contribution Guidelines and Code of Conduct (1m, Lee)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+   - [Contribution Guide](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Lee)
+1. Determine volunteers for note taking (1m, Lee)
+1. Review agenda (2m, Lee)
+1. Review previous meeting's action items (5m, Lee)
+   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
+   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)

--- a/agendas/2022/10-Oct/wg-secondary-apac.md
+++ b/agendas/2022/10-Oct/wg-secondary-apac.md
@@ -1,0 +1,115 @@
+<!--
+
+Hello! You're welcome to join our working group meeting and add to the agenda
+by following these three steps:
+
+   1. Add your name to the list of attendees (in alphabetical order).
+
+      - To respect meeting size, attendees should be relevant to the agenda.
+        That means we expect most who join the meeting to participate in
+        discussion. If you'd rather just watch, check out our YouTube[1].
+
+      - Please include the organization (or project) you represent, and the
+        location (including country code[2]) you expect to be located in during
+        the meeting.
+
+      - If you're willing to help take notes, add "✏️" after your name
+        (eg. Ada Lovelace ✏). This is hugely helpful!
+
+   2. If relevant, add your topic to the agenda (sorted by expected time).
+
+      - Every agenda item has four parts: 1) the topic, 2) an expected time
+        constraint, 3) who's leading the discussion, and 4) a list of any
+        relevant links (RFC docs, issues, PRs, presentations, etc). Follow the
+        format of existing agenda items.
+
+      - Know what you want to get out of the agenda topic - what feedback do you
+        need? What questions do you need answered? Are you looking for consensus
+        or just directional feedback?
+
+      - If your topic is a new proposal it's likely an "RFC 0"[3]. The barrier
+        of entry for documenting new proposals is intentionally low, writing a
+        few sentences about the problem you're trying to solve and the rough
+        shape of your proposed solution is normally sufficient.
+
+        You can create a link for this:
+          - As an issue against the graphql-wg repo.
+          - As a GitHub discussion in the graphql-wg repo.
+          - As an RFC document into the rfcs/ folder of the graphql-wg repo.
+
+   3. Review our guidelines and agree to our Spec Membership & CLA.
+
+      - Review and understand our Spec Membership Agreement, Participation &
+        Contribution Guidelines, and Code of Conduct. You'll find links to these
+        in the first agenda item of every meeting.
+
+      - If this is your first time, our bot will comment on your Pull Request
+        with a link to our Spec Membership & CLA. Please follow along and agree
+        before your PR is merged.
+
+        Your organization may sign this for all of its members. To set this up,
+        please ask operations@graphql.org.
+
+PLEASE TAKE NOTE:
+
+  - By joining this meeting you must agree to the Specification Membership
+    Agreement and Code of Conduct.
+
+  - Meetings are recorded and made available on YouTube[1], by joining you
+    consent to being recorded.
+
+[1] Youtube: https://www.youtube.com/channel/UCERcwLeheOXp_u61jEXxHMA
+[2] Country codes: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes
+[3] RFC stages: https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#rfc-contribution-stages
+
+-->
+
+| This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
+| ---------------------------------------------------------------------------------------- |
+
+# GraphQL WG – October 2022 (Secondary, APAC)
+
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
+
+This is a secondary meeting, timed to be acceptable for those in Asia Pacific
+timezones, which typically meets on the second Wednesday of the month. The
+primary meeting is preferred for new agenda, where this meeting is for overflow
+agenda items, follow ups from the primary meeting, or agenda introduced by those
+who could not make the primary meeting time.
+
+- **Date & Time**: [October 12th 2022 3:30pm - 5:00pm PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221012T223000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+  - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
+  - _Please Note:_ The date or time may change. Please check this agenda the
+    week of the meeting to confirm. While we try to keep all calendars accurate,
+    this agenda document is the source of truth.
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
+
+[graphql specification]: https://github.com/graphql/graphql-spec
+[calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
+
+## Attendees
+
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
+
+## Agenda
+
+1. Agree to Membership Agreement, Participation & Contribution Guidelines and Code of Conduct (1m, Lee)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+   - [Contribution Guide](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Lee)
+1. Determine volunteers for note taking (1m, Lee)
+1. Review agenda (2m, Lee)
+1. Review previous meeting's action items (5m, Lee)
+   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
+   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)

--- a/agendas/2022/10-Oct/wg-secondary-eu.md
+++ b/agendas/2022/10-Oct/wg-secondary-eu.md
@@ -65,36 +65,39 @@ PLEASE TAKE NOTE:
 -->
 
 | This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
-| --- |
+| ---------------------------------------------------------------------------------------- |
 
+# GraphQL WG – October 2022 (Secondary, EU)
 
-# GraphQL WG – December 2022
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
 
-The GraphQL Working Group meets monthly to discuss proposed additions to the
-[GraphQL Specification][] and other relevant topics to core GraphQL projects.
-This is an open meeting in which anyone in the GraphQL community may attend.
+This is a secondary meeting, timed to be acceptable for those in European
+timezones, which typically meets on the third Thursday of the month. The
+primary meeting is preferred for new agenda, where this meeting is for overflow
+agenda items, follow ups from the primary meeting, or agenda introduced by those
+who could not make the primary meeting time.
 
-- **Date & Time**: [December 1st 2022 19:00 - 21:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=12&day=1&hour=19&min=0&sec=0&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=240&iv=0)
+- **Date & Time**: [October 20th 2022 10:30am - 12:00noon PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221020T173000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
-  - *Please Note:* The date or time may change. Please check this agenda the
+  - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,
     this agenda document is the source of truth.
 - **Video Conference Link**: https://zoom.us/j/593263740
-  - *Password:* graphqlwg
-- **Live Notes**: [Google Doc](about:blank)
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
 
-[GraphQL Specification]: https://github.com/graphql/graphql-spec
+[graphql specification]: https://github.com/graphql/graphql-spec
 [calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
-[Google Calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
 [ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
-
 
 ## Attendees
 
-| Name               | GitHub          | Organization       | Location
-| :----------------- | :-------------- | :----------------- | :-----------------
-| Lee Byron          | @leebyron       | GraphQL Foundation | San Francisco, CA, US
-
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
 
 ## Agenda
 

--- a/agendas/2022/11-Nov/wg-primary.md
+++ b/agendas/2022/11-Nov/wg-primary.md
@@ -1,0 +1,113 @@
+<!--
+
+Hello! You're welcome to join our working group meeting and add to the agenda
+by following these three steps:
+
+   1. Add your name to the list of attendees (in alphabetical order).
+
+      - To respect meeting size, attendees should be relevant to the agenda.
+        That means we expect most who join the meeting to participate in
+        discussion. If you'd rather just watch, check out our YouTube[1].
+
+      - Please include the organization (or project) you represent, and the
+        location (including country code[2]) you expect to be located in during
+        the meeting.
+
+      - If you're willing to help take notes, add "✏️" after your name
+        (eg. Ada Lovelace ✏). This is hugely helpful!
+
+   2. If relevant, add your topic to the agenda (sorted by expected time).
+
+      - Every agenda item has four parts: 1) the topic, 2) an expected time
+        constraint, 3) who's leading the discussion, and 4) a list of any
+        relevant links (RFC docs, issues, PRs, presentations, etc). Follow the
+        format of existing agenda items.
+
+      - Know what you want to get out of the agenda topic - what feedback do you
+        need? What questions do you need answered? Are you looking for consensus
+        or just directional feedback?
+
+      - If your topic is a new proposal it's likely an "RFC 0"[3]. The barrier
+        of entry for documenting new proposals is intentionally low, writing a
+        few sentences about the problem you're trying to solve and the rough
+        shape of your proposed solution is normally sufficient.
+
+        You can create a link for this:
+          - As an issue against the graphql-wg repo.
+          - As a GitHub discussion in the graphql-wg repo.
+          - As an RFC document into the rfcs/ folder of the graphql-wg repo.
+
+   3. Review our guidelines and agree to our Spec Membership & CLA.
+
+      - Review and understand our Spec Membership Agreement, Participation &
+        Contribution Guidelines, and Code of Conduct. You'll find links to these
+        in the first agenda item of every meeting.
+
+      - If this is your first time, our bot will comment on your Pull Request
+        with a link to our Spec Membership & CLA. Please follow along and agree
+        before your PR is merged.
+
+        Your organization may sign this for all of its members. To set this up,
+        please ask operations@graphql.org.
+
+PLEASE TAKE NOTE:
+
+  - By joining this meeting you must agree to the Specification Membership
+    Agreement and Code of Conduct.
+
+  - Meetings are recorded and made available on YouTube[1], by joining you
+    consent to being recorded.
+
+[1] Youtube: https://www.youtube.com/channel/UCERcwLeheOXp_u61jEXxHMA
+[2] Country codes: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes
+[3] RFC stages: https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#rfc-contribution-stages
+
+-->
+
+| This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
+| ---------------------------------------------------------------------------------------- |
+
+# GraphQL WG – November 2022 (Primary)
+
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
+
+This is our primary monthly meeting, which typically meets on the first Thursday
+of the month. In the case we have additional agenda items or follow ups, we also
+hold additional secondary meetings later in the month.
+
+- **Date & Time**: [November 3rd 2022 10:30am - 12:00noon PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221103T173000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+  - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
+  - _Please Note:_ The date or time may change. Please check this agenda the
+    week of the meeting to confirm. While we try to keep all calendars accurate,
+    this agenda document is the source of truth.
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
+
+[graphql specification]: https://github.com/graphql/graphql-spec
+[calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
+
+## Attendees
+
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
+
+## Agenda
+
+1. Agree to Membership Agreement, Participation & Contribution Guidelines and Code of Conduct (1m, Lee)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+   - [Contribution Guide](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Lee)
+1. Determine volunteers for note taking (1m, Lee)
+1. Review agenda (2m, Lee)
+1. Review previous meeting's action items (5m, Lee)
+   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
+   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)

--- a/agendas/2022/11-Nov/wg-secondary-apac.md
+++ b/agendas/2022/11-Nov/wg-secondary-apac.md
@@ -1,0 +1,115 @@
+<!--
+
+Hello! You're welcome to join our working group meeting and add to the agenda
+by following these three steps:
+
+   1. Add your name to the list of attendees (in alphabetical order).
+
+      - To respect meeting size, attendees should be relevant to the agenda.
+        That means we expect most who join the meeting to participate in
+        discussion. If you'd rather just watch, check out our YouTube[1].
+
+      - Please include the organization (or project) you represent, and the
+        location (including country code[2]) you expect to be located in during
+        the meeting.
+
+      - If you're willing to help take notes, add "✏️" after your name
+        (eg. Ada Lovelace ✏). This is hugely helpful!
+
+   2. If relevant, add your topic to the agenda (sorted by expected time).
+
+      - Every agenda item has four parts: 1) the topic, 2) an expected time
+        constraint, 3) who's leading the discussion, and 4) a list of any
+        relevant links (RFC docs, issues, PRs, presentations, etc). Follow the
+        format of existing agenda items.
+
+      - Know what you want to get out of the agenda topic - what feedback do you
+        need? What questions do you need answered? Are you looking for consensus
+        or just directional feedback?
+
+      - If your topic is a new proposal it's likely an "RFC 0"[3]. The barrier
+        of entry for documenting new proposals is intentionally low, writing a
+        few sentences about the problem you're trying to solve and the rough
+        shape of your proposed solution is normally sufficient.
+
+        You can create a link for this:
+          - As an issue against the graphql-wg repo.
+          - As a GitHub discussion in the graphql-wg repo.
+          - As an RFC document into the rfcs/ folder of the graphql-wg repo.
+
+   3. Review our guidelines and agree to our Spec Membership & CLA.
+
+      - Review and understand our Spec Membership Agreement, Participation &
+        Contribution Guidelines, and Code of Conduct. You'll find links to these
+        in the first agenda item of every meeting.
+
+      - If this is your first time, our bot will comment on your Pull Request
+        with a link to our Spec Membership & CLA. Please follow along and agree
+        before your PR is merged.
+
+        Your organization may sign this for all of its members. To set this up,
+        please ask operations@graphql.org.
+
+PLEASE TAKE NOTE:
+
+  - By joining this meeting you must agree to the Specification Membership
+    Agreement and Code of Conduct.
+
+  - Meetings are recorded and made available on YouTube[1], by joining you
+    consent to being recorded.
+
+[1] Youtube: https://www.youtube.com/channel/UCERcwLeheOXp_u61jEXxHMA
+[2] Country codes: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes
+[3] RFC stages: https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#rfc-contribution-stages
+
+-->
+
+| This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
+| ---------------------------------------------------------------------------------------- |
+
+# GraphQL WG – November 2022 (Secondary, APAC)
+
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
+
+This is a secondary meeting, timed to be acceptable for those in Asia Pacific
+timezones, which typically meets on the second Wednesday of the month. The
+primary meeting is preferred for new agenda, where this meeting is for overflow
+agenda items, follow ups from the primary meeting, or agenda introduced by those
+who could not make the primary meeting time.
+
+- **Date & Time**: [November 9th 2022 3:30pm - 5:00pm PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221109T233000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+  - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
+  - _Please Note:_ The date or time may change. Please check this agenda the
+    week of the meeting to confirm. While we try to keep all calendars accurate,
+    this agenda document is the source of truth.
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
+
+[graphql specification]: https://github.com/graphql/graphql-spec
+[calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
+
+## Attendees
+
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
+
+## Agenda
+
+1. Agree to Membership Agreement, Participation & Contribution Guidelines and Code of Conduct (1m, Lee)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+   - [Contribution Guide](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Lee)
+1. Determine volunteers for note taking (1m, Lee)
+1. Review agenda (2m, Lee)
+1. Review previous meeting's action items (5m, Lee)
+   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
+   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)

--- a/agendas/2022/11-Nov/wg-secondary-eu.md
+++ b/agendas/2022/11-Nov/wg-secondary-eu.md
@@ -1,0 +1,115 @@
+<!--
+
+Hello! You're welcome to join our working group meeting and add to the agenda
+by following these three steps:
+
+   1. Add your name to the list of attendees (in alphabetical order).
+
+      - To respect meeting size, attendees should be relevant to the agenda.
+        That means we expect most who join the meeting to participate in
+        discussion. If you'd rather just watch, check out our YouTube[1].
+
+      - Please include the organization (or project) you represent, and the
+        location (including country code[2]) you expect to be located in during
+        the meeting.
+
+      - If you're willing to help take notes, add "✏️" after your name
+        (eg. Ada Lovelace ✏). This is hugely helpful!
+
+   2. If relevant, add your topic to the agenda (sorted by expected time).
+
+      - Every agenda item has four parts: 1) the topic, 2) an expected time
+        constraint, 3) who's leading the discussion, and 4) a list of any
+        relevant links (RFC docs, issues, PRs, presentations, etc). Follow the
+        format of existing agenda items.
+
+      - Know what you want to get out of the agenda topic - what feedback do you
+        need? What questions do you need answered? Are you looking for consensus
+        or just directional feedback?
+
+      - If your topic is a new proposal it's likely an "RFC 0"[3]. The barrier
+        of entry for documenting new proposals is intentionally low, writing a
+        few sentences about the problem you're trying to solve and the rough
+        shape of your proposed solution is normally sufficient.
+
+        You can create a link for this:
+          - As an issue against the graphql-wg repo.
+          - As a GitHub discussion in the graphql-wg repo.
+          - As an RFC document into the rfcs/ folder of the graphql-wg repo.
+
+   3. Review our guidelines and agree to our Spec Membership & CLA.
+
+      - Review and understand our Spec Membership Agreement, Participation &
+        Contribution Guidelines, and Code of Conduct. You'll find links to these
+        in the first agenda item of every meeting.
+
+      - If this is your first time, our bot will comment on your Pull Request
+        with a link to our Spec Membership & CLA. Please follow along and agree
+        before your PR is merged.
+
+        Your organization may sign this for all of its members. To set this up,
+        please ask operations@graphql.org.
+
+PLEASE TAKE NOTE:
+
+  - By joining this meeting you must agree to the Specification Membership
+    Agreement and Code of Conduct.
+
+  - Meetings are recorded and made available on YouTube[1], by joining you
+    consent to being recorded.
+
+[1] Youtube: https://www.youtube.com/channel/UCERcwLeheOXp_u61jEXxHMA
+[2] Country codes: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes
+[3] RFC stages: https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#rfc-contribution-stages
+
+-->
+
+| This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
+| ---------------------------------------------------------------------------------------- |
+
+# GraphQL WG – November 2022 (Secondary, EU)
+
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
+
+This is a secondary meeting, timed to be acceptable for those in European
+timezones, which typically meets on the third Thursday of the month. The
+primary meeting is preferred for new agenda, where this meeting is for overflow
+agenda items, follow ups from the primary meeting, or agenda introduced by those
+who could not make the primary meeting time.
+
+- **Date & Time**: [November 17th 2022 10:30am - 12:00noon PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221117T183000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+  - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
+  - _Please Note:_ The date or time may change. Please check this agenda the
+    week of the meeting to confirm. While we try to keep all calendars accurate,
+    this agenda document is the source of truth.
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
+
+[graphql specification]: https://github.com/graphql/graphql-spec
+[calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
+
+## Attendees
+
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
+
+## Agenda
+
+1. Agree to Membership Agreement, Participation & Contribution Guidelines and Code of Conduct (1m, Lee)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+   - [Contribution Guide](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Lee)
+1. Determine volunteers for note taking (1m, Lee)
+1. Review agenda (2m, Lee)
+1. Review previous meeting's action items (5m, Lee)
+   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
+   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)

--- a/agendas/2022/12-Dec/wg-primary.md
+++ b/agendas/2022/12-Dec/wg-primary.md
@@ -1,0 +1,113 @@
+<!--
+
+Hello! You're welcome to join our working group meeting and add to the agenda
+by following these three steps:
+
+   1. Add your name to the list of attendees (in alphabetical order).
+
+      - To respect meeting size, attendees should be relevant to the agenda.
+        That means we expect most who join the meeting to participate in
+        discussion. If you'd rather just watch, check out our YouTube[1].
+
+      - Please include the organization (or project) you represent, and the
+        location (including country code[2]) you expect to be located in during
+        the meeting.
+
+      - If you're willing to help take notes, add "✏️" after your name
+        (eg. Ada Lovelace ✏). This is hugely helpful!
+
+   2. If relevant, add your topic to the agenda (sorted by expected time).
+
+      - Every agenda item has four parts: 1) the topic, 2) an expected time
+        constraint, 3) who's leading the discussion, and 4) a list of any
+        relevant links (RFC docs, issues, PRs, presentations, etc). Follow the
+        format of existing agenda items.
+
+      - Know what you want to get out of the agenda topic - what feedback do you
+        need? What questions do you need answered? Are you looking for consensus
+        or just directional feedback?
+
+      - If your topic is a new proposal it's likely an "RFC 0"[3]. The barrier
+        of entry for documenting new proposals is intentionally low, writing a
+        few sentences about the problem you're trying to solve and the rough
+        shape of your proposed solution is normally sufficient.
+
+        You can create a link for this:
+          - As an issue against the graphql-wg repo.
+          - As a GitHub discussion in the graphql-wg repo.
+          - As an RFC document into the rfcs/ folder of the graphql-wg repo.
+
+   3. Review our guidelines and agree to our Spec Membership & CLA.
+
+      - Review and understand our Spec Membership Agreement, Participation &
+        Contribution Guidelines, and Code of Conduct. You'll find links to these
+        in the first agenda item of every meeting.
+
+      - If this is your first time, our bot will comment on your Pull Request
+        with a link to our Spec Membership & CLA. Please follow along and agree
+        before your PR is merged.
+
+        Your organization may sign this for all of its members. To set this up,
+        please ask operations@graphql.org.
+
+PLEASE TAKE NOTE:
+
+  - By joining this meeting you must agree to the Specification Membership
+    Agreement and Code of Conduct.
+
+  - Meetings are recorded and made available on YouTube[1], by joining you
+    consent to being recorded.
+
+[1] Youtube: https://www.youtube.com/channel/UCERcwLeheOXp_u61jEXxHMA
+[2] Country codes: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes
+[3] RFC stages: https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md#rfc-contribution-stages
+
+-->
+
+| This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
+| ---------------------------------------------------------------------------------------- |
+
+# GraphQL WG – December 2022 (Primary)
+
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
+
+This is our primary monthly meeting, which typically meets on the first Thursday
+of the month. In the case we have additional agenda items or follow ups, we also
+hold additional secondary meetings later in the month.
+
+- **Date & Time**: [December 1st 2022 10:30am - 12:00noon PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221201T183000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+  - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
+  - _Please Note:_ The date or time may change. Please check this agenda the
+    week of the meeting to confirm. While we try to keep all calendars accurate,
+    this agenda document is the source of truth.
+- **Video Conference Link**: https://zoom.us/j/593263740
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
+
+[graphql specification]: https://github.com/graphql/graphql-spec
+[calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
+
+## Attendees
+
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
+
+## Agenda
+
+1. Agree to Membership Agreement, Participation & Contribution Guidelines and Code of Conduct (1m, Lee)
+   - [Specification Membership Agreement](https://github.com/graphql/foundation)
+   - [Participation Guidelines](https://github.com/graphql/graphql-wg#participation-guidelines)
+   - [Contribution Guide](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md)
+   - [Code of Conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md)
+1. Introduction of attendees (5m, Lee)
+1. Determine volunteers for note taking (1m, Lee)
+1. Review agenda (2m, Lee)
+1. Review previous meeting's action items (5m, Lee)
+   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
+   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)

--- a/agendas/2022/12-Dec/wg-secondary-apac.md
+++ b/agendas/2022/12-Dec/wg-secondary-apac.md
@@ -65,36 +65,39 @@ PLEASE TAKE NOTE:
 -->
 
 | This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
-| --- |
+| ---------------------------------------------------------------------------------------- |
 
+# GraphQL WG – November 2022 (Secondary, APAC)
 
-# GraphQL WG – October 2022
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
 
-The GraphQL Working Group meets monthly to discuss proposed additions to the
-[GraphQL Specification][] and other relevant topics to core GraphQL projects.
-This is an open meeting in which anyone in the GraphQL community may attend.
+This is a secondary meeting, timed to be acceptable for those in Asia Pacific
+timezones, which typically meets on the second Wednesday of the month. The
+primary meeting is preferred for new agenda, where this meeting is for overflow
+agenda items, follow ups from the primary meeting, or agenda introduced by those
+who could not make the primary meeting time.
 
-- **Date & Time**: [October 6th 2022 18:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=10&day=6&hour=18&min=0&sec=0&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=240&iv=0)
+- **Date & Time**: [December 7th 2022 3:30pm - 5:00pm PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221207T233000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
-  - *Please Note:* The date or time may change. Please check this agenda the
+  - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,
     this agenda document is the source of truth.
 - **Video Conference Link**: https://zoom.us/j/593263740
-  - *Password:* graphqlwg
-- **Live Notes**: [Google Doc](about:blank)
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
 
-[GraphQL Specification]: https://github.com/graphql/graphql-spec
+[graphql specification]: https://github.com/graphql/graphql-spec
 [calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
-[Google Calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
 [ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
-
 
 ## Attendees
 
-| Name               | GitHub          | Organization       | Location
-| :----------------- | :-------------- | :----------------- | :-----------------
-| Lee Byron          | @leebyron       | GraphQL Foundation | San Francisco, CA, US
-
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
 
 ## Agenda
 

--- a/agendas/2022/12-Dec/wg-secondary-eu.md
+++ b/agendas/2022/12-Dec/wg-secondary-eu.md
@@ -65,36 +65,39 @@ PLEASE TAKE NOTE:
 -->
 
 | This is an open meeting: To attend or add agenda, send a Pull Request against this file. |
-| --- |
+| ---------------------------------------------------------------------------------------- |
 
+# GraphQL WG – December 2022 (Secondary, EU)
 
-# GraphQL WG – November 2022
+The GraphQL Working Group meets regularly to discuss changes to the
+[GraphQL Specification][] and other core GraphQL projects. This is an open
+meeting in which anyone in the GraphQL community may attend.
 
-The GraphQL Working Group meets monthly to discuss proposed additions to the
-[GraphQL Specification][] and other relevant topics to core GraphQL projects.
-This is an open meeting in which anyone in the GraphQL community may attend.
+This is a secondary meeting, timed to be acceptable for those in European
+timezones, which typically meets on the third Thursday of the month. The
+primary meeting is preferred for new agenda, where this meeting is for overflow
+agenda items, follow ups from the primary meeting, or agenda introduced by those
+who could not make the primary meeting time.
 
-- **Date & Time**: [November 3rd 2022 18:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2022&month=11&day=3&hour=18&min=0&sec=0&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=240&iv=0)
+- **Date & Time**: [December 15th 2022 10:30am - 12:00noon PT](https://www.timeanddate.com/worldclock/converter.html?iso=20221215T183000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
-  - *Please Note:* The date or time may change. Please check this agenda the
+  - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,
     this agenda document is the source of truth.
 - **Video Conference Link**: https://zoom.us/j/593263740
-  - *Password:* graphqlwg
-- **Live Notes**: [Google Doc](about:blank)
+  - _Password:_ graphqlwg
+- **Live Notes**: [Google Doc]()
 
-[GraphQL Specification]: https://github.com/graphql/graphql-spec
+[graphql specification]: https://github.com/graphql/graphql-spec
 [calendar]: https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com
-[Google Calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
+[google calendar]: https://calendar.google.com/calendar?cid=bGludXhmb3VuZGF0aW9uLm9yZ19pazc5dDl1dWoycDMyaTNyMjAzZGd2NW1vOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t
 [ical file]: https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics
-
 
 ## Attendees
 
-| Name               | GitHub          | Organization       | Location
-| :----------------- | :-------------- | :----------------- | :-----------------
-| Lee Byron          | @leebyron       | GraphQL Foundation | San Francisco, CA, US
-
+| Name             | GitHub    | Organization       | Location              |
+| :--------------- | :-------- | :----------------- | :-------------------- |
+| Lee Byron (Host) | @leebyron | GraphQL Foundation | San Francisco, CA, US |
 
 ## Agenda
 


### PR DESCRIPTION
This is an implemented final proposal for [Changed Working Group times](https://github.com/graphql/graphql-wg/discussions/1051)

As a short recap, a couple meetings ago the topic was raised to take a fresh look at our meeting cadence based on a few concerns:

- A two hour meeting was a little too long
- Timing was late in the day for EU
- Timing was middle of the night for APAC
- Agendas ran over, without a path for overflow
- Significant progress is being made, and a monthly cadence isn't frequent enough.

This changes timing as follows:

- The existing WG meeting is now named "Primary", remains on first Thursdays, but is reduced to 1.5hr and shifted slightly earlier.
- Two new "Secondary" WG meetings are added, one at the same time on third Thursdays, and one +5hr on second Wednesdays to be more APAC available.

This also revises agenda templates and file system:

- Year/Month/ becomes a directory with named meeting agenda files within
- Updated intro text describing the meeting purpose
- Updated the timeanddate links to use the newer meeting scheduling tool.
- List times in Pacific Time instead of UTC, since that is how our calendar entries have been working.

Finally, this adds tables of all meetings for WG and subcommittees in the repo README.