### PR TITLE
Add hwillson to the 2022-10-20 WG agenda

### DIFF
--- a/agendas/2022/10-Oct/wg-secondary-eu.md
+++ b/agendas/2022/10-Oct/wg-secondary-eu.md
@@ -101,6 +101,7 @@ who could not make the primary meeting time.
 | Yaacov Rydzinski | @yaacovcr | Individual         | Neve Daniel, IL       |
 | Benjie Gillam    | @benjie   | Graphile           | Chandler's Ford, UK   |
 | Michael Staib    | @michaelstaib | ChilliCream    | Zurich, CH            |
+| Hugh Willson     | @hwillson | Apollo             | Ottawa, ON, CA        |
 
 ## Agenda
 


### PR DESCRIPTION
I'd love to attend!

One super small note as well - the public [calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com) has the call starting at 10:30 am Pacific, but the agenda doc mentions 11 am Pacific.

Thanks!