### PR TITLE
add myself to 2023-03-03 meeting, add agenda item

### DIFF
--- a/agendas/2023/03-Mar/02-wg-primary.md
+++ b/agendas/2023/03-Mar/02-wg-primary.md
@@ -123,4 +123,4 @@ hold additional secondary meetings later in the month.
    - [RFC spec text](https://github.com/graphql/graphql-spec/pull/1015)
    - [GraphQL.js PR](https://github.com/graphql/graphql-js/pull/3846)
 1. Discuss GraphiQL v3 big features and request-for-help (10m, Jonathan)
-1. `@graphiql/*` npm write access issues blocking releases since January
+1. `@graphiql/*` npm write access issues blocking releases since January (10m, Rikki)

--- a/agendas/2023/03-Mar/02-wg-primary.md
+++ b/agendas/2023/03-Mar/02-wg-primary.md
@@ -100,6 +100,7 @@ hold additional secondary meetings later in the month.
 | :--------------- | :--------------- | :----------------- | :-------------------- |
 | Lee Byron (Host) | @leebyron        | GraphQL Foundation | San Francisco, CA, US |
 | Jonathan Brennan | @jonathanawesome | Grafbase           | Austin, TX, US        |
+| Rikki Schulte    | @acao            | Recarb             | Berlin, DE            |
 
 ## Agenda
 
@@ -122,3 +123,4 @@ hold additional secondary meetings later in the month.
    - [RFC spec text](https://github.com/graphql/graphql-spec/pull/1015)
    - [GraphQL.js PR](https://github.com/graphql/graphql-js/pull/3846)
 1. Discuss GraphiQL v3 big features and request-for-help (10m, Jonathan)
+1. `@graphiql/*` npm write access issues blocking releases since January


### PR DESCRIPTION
Hopefully this will be resolved by march, but we would really like to be able to publish another release from the graphiql monorepo. We haven't been able to publish to `@graphiql` scope since last year.