### PR TITLE
Add Benjie & Field merging stream/defer to April WG

### DIFF
--- a/agendas/2023/04-Apr/06-wg-primary.md
+++ b/agendas/2023/04-Apr/06-wg-primary.md
@@ -99,6 +99,7 @@ hold additional secondary meetings later in the month.
 | Name             | GitHub        | Organization       | Location              |
 | :--------------- | :------------ | :----------------- | :-------------------- |
 | Lee Byron (Host) | @leebyron     | GraphQL Foundation | San Francisco, CA, US |
+| Benjie Gillam    | @benjie       | Graphile           | Chandler's Ford, UK   |
 
 ## Agenda
 
@@ -117,3 +118,6 @@ hold additional secondary meetings later in the month.
    - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
    - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
    - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
+1. Field merging approach to incremental delivery (45m, Benjie and Rob)
+   - [Spec PR](https://github.com/graphql/graphql-spec/pull/1018)
+   - [More example queries](https://github.com/robrichard/defer-stream-wg/discussions/65#discussioncomment-5217957)


### PR DESCRIPTION
This is likely to be a long discussion because a lot of background needs to be laid first.

We're also adding it to the April primary WG to give the incremental delivery WG a couple weeks to have a think about the proposal and do any improvements before we ask for feedback from the main WG.

All other topics should be added above this one.

cc @robrichard, please add yourself to the agenda! :)