### PR TITLE
Improvements to gen-agenda script

### DIFF
--- a/agendas/2023/07-Jul/06-wg-primary.md
+++ b/agendas/2023/07-Jul/06-wg-primary.md
@@ -81,7 +81,7 @@ This is the primary monthly meeting, which typically meets on the first Thursday
 of the month. In the case we have additional agenda items or follow ups, we also
 hold additional secondary meetings later in the month.
 
-- **Date & Time**: [July 6, 2023 at 10:30 AM - 12:00 PM PDT](https://www.timeanddate.com/worldclock/converter.html?iso=20230706T173000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+- **Date & Time**: [July 6, 2023, 10:30 AM – 12:00 PM PDT](https://www.timeanddate.com/worldclock/converter.html?iso=20230706T173000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2023/07-Jul/12-wg-secondary-apac.md
+++ b/agendas/2023/07-Jul/12-wg-secondary-apac.md
@@ -83,7 +83,7 @@ primary meeting is preferred for new agenda, where this meeting is for overflow
 agenda items, follow ups from the primary meeting, or agenda introduced by those
 who could not make the primary meeting time.
 
-- **Date & Time**: [July 12, 2023 at 4:00 PM - 5:00 PM PDT](https://www.timeanddate.com/worldclock/converter.html?iso=20230712T230000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+- **Date & Time**: [July 12, 2023, 4:00 – 5:00 PM PDT](https://www.timeanddate.com/worldclock/converter.html?iso=20230712T230000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/agendas/2023/07-Jul/20-wg-secondary-eu.md
+++ b/agendas/2023/07-Jul/20-wg-secondary-eu.md
@@ -83,7 +83,7 @@ primary meeting is preferred for new agenda, where this meeting is for overflow
 agenda items, follow ups from the primary meeting, or agenda introduced by those
 who could not make the primary meeting time.
 
-- **Date & Time**: [July 20, 2023 at 10:30 AM - 12:00 PM PDT](https://www.timeanddate.com/worldclock/converter.html?iso=20230720T173000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+- **Date & Time**: [July 20, 2023, 10:30 AM – 12:00 PM PDT](https://www.timeanddate.com/worldclock/converter.html?iso=20230720T173000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,

--- a/tools/gen-agenda.js
+++ b/tools/gen-agenda.js
@@ -26,6 +26,17 @@ if (!year || !month) {
 `);
   process.exit(1);
 }
+const today = new Date();
+if (year < today.getFullYear() - 3 || year > today.getFullYear() + 9) {
+  console.error(
+    `Invalid year '${year}', please select a recent or close future year`
+  );
+  process.exit(1);
+}
+if (month < 1 || month > 12) {
+  console.error(`Invalid month '${month}', must be between 1 and 12`);
+  process.exit(1);
+}
 
 // For all three meetings in a month, fill and write the template
 for (num = 0; num < 3; num++) {

--- a/tools/gen-agenda.js
+++ b/tools/gen-agenda.js
@@ -13,6 +13,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const { inspect } = require("util");
 
 // Get arguments
 const [year, month] = process.argv
@@ -67,7 +68,7 @@ agenda items, follow ups from the primary meeting, or agenda introduced by those
 who could not make the primary meeting time.`,
   ][meeting.num];
 
-  return `<!--
+  return t`<!--
 
 # How to join (copied directly from /JoiningAMeeting.md)
 
@@ -78,7 +79,7 @@ ${howToJoin}
 | This is an open meeting: To attend, read [JoiningAMeeting.md][] then edit and PR this file. (Edit: ✎ above, or press "e") |
 | ---------------------------------------------------------------------------------------- |
 
-# GraphQL WG – ${t(meeting.monthName)} ${t(meeting.year)} (${t(meeting.name)})
+# GraphQL WG – ${meeting.monthName} ${meeting.year} (${meeting.name})
 
 The GraphQL Working Group meets regularly to discuss changes to the
 [GraphQL Specification][] and other core GraphQL projects. This is an open
@@ -86,7 +87,7 @@ meeting in which anyone in the GraphQL community may attend.
 
 ${meetingDescription}
 
-- **Date & Time**: [${t(meeting.dateTimeDuration)}](${t(meeting.timeLink)})
+- **Date & Time**: [${meeting.dateTimeDuration}](${meeting.timeLink})
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,
@@ -120,12 +121,8 @@ ${meetingDescription}
 1. Determine volunteers for note taking (1m, Lee)
 1. Review agenda (2m, Lee)
 1. Review prior secondary meetings (5m, Lee)
-   - [${t(prior2Meeting.monthName)} WG ${t(prior2Meeting.name)}](${t(
-    prior2Meeting.url
-  )})
-   - [${t(prior1Meeting.monthName)} WG ${t(prior1Meeting.name)}](${t(
-    prior1Meeting.url
-  )})
+   - [${prior2Meeting.monthName} WG ${prior2Meeting.name}](${prior2Meeting.url})
+   - [${prior1Meeting.monthName} WG ${prior1Meeting.name}](${prior1Meeting.url})
 1. Review previous meeting's action items (5m, Lee)
    - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
    - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
@@ -133,11 +130,23 @@ ${meetingDescription}
 `;
 }
 
-function t(v) {
-  if (!v) {
-    throw new Error(`Missing value`);
+function t(strings, ...placeholders) {
+  let string = "";
+  for (let i = 0, l = strings.length; i < l; i++) {
+    string += strings[i];
+    if (i < l - 1) {
+      const v = placeholders[i];
+      if (!v) {
+        throw new Error(
+          `Placeholder ${i} in template string is falsy (val = ${inspect(v, {
+            colors: true,
+          })})`
+        );
+      }
+      string += String(v);
+    }
   }
-  return v;
+  return string;
 }
 
 function getMeeting(year, month, num) {

--- a/tools/gen-agenda.js
+++ b/tools/gen-agenda.js
@@ -171,7 +171,7 @@ function getMeeting(year, month, num) {
   //  - The first meeting is first Thursday.
   //  - Second is the following Wednesday after the first.
   //  - Third is two weeks following the first, also on a Thursday.
-  const monthStartWeekday = new Date(year, month - 1, 1).getDay();
+  const monthStartWeekday = new Date(year, month - 1, 1, 12).getDay();
   const firstThursday = new Date(
     year,
     month - 1,
@@ -210,9 +210,18 @@ function getMeeting(year, month, num) {
   const isoTime = dateTime.toISOString().replace(/[:-]/g, "").slice(0, 15);
   const timeLink = `https://www.timeanddate.com/worldclock/converter.html?iso=${isoTime}&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240`;
 
-  const monthShort = dateTime.toLocaleString("en-US", { month: "short" });
-  const month2D = dateTime.toLocaleString("en-US", { month: "2-digit" });
-  const day2D = dateTime.toLocaleString("en-US", { day: "2-digit" });
+  const monthShort = dateTime.toLocaleString("en-US", {
+    month: "short",
+    timeZone: "America/Los_Angeles",
+  });
+  const month2D = dateTime.toLocaleString("en-US", {
+    month: "2-digit",
+    timeZone: "America/Los_Angeles",
+  });
+  const day2D = dateTime.toLocaleString("en-US", {
+    day: "2-digit",
+    timeZone: "America/Los_Angeles",
+  });
   const fileName = ["wg-primary", "wg-secondary-apac", "wg-secondary-eu"][num];
   const repoPath = `agendas/${year}/${month2D}-${monthShort}/${day2D}-${fileName}.md`;
 
@@ -250,13 +259,13 @@ function getPriorMeeting(meeting) {
 
 // Times are in Pacific Time
 function getDateTime(year, month, date, time) {
-  const iso = new Date(year, month - 1, date).toISOString();
+  const yyyy = String(year);
+  const mm = String(month).padStart(2, "0");
+  const dd = String(date).padStart(2, "0");
   // Timezones are hard. This iterates through a few offsets until we find the
   // one which has a time which matches the expected time.
   for (let offset = 7; offset <= 8; offset++) {
-    const d = new Date(
-      iso.slice(0, 11) + time + iso.slice(16, -1) + "-0" + offset + ":00"
-    );
+    const d = new Date(`${yyyy}-${mm}-${dd}T${time}:00-0${offset}:00`);
     if (
       time ===
       d.toLocaleTimeString("en-US", {


### PR DESCRIPTION
- Switched from using `t(...)` placeholders to using `` t`...` `` tagged template literal - allows adding more interpolation in future without having to remember to wrap in `t(...)` (plus, easier to read)
- Basic validation on the inputs
- Tweak the timezone code so that consistent filenames and times are generated from the UK (please test this still works correctly in US; it should but I'm not certain)