### PR TITLE
Add Meta Relay Error Handling WG to Sep GraphQL WG meeting

### DIFF
--- a/agendas/2023/09-Sep/07-wg-primary.md
+++ b/agendas/2023/09-Sep/07-wg-primary.md
@@ -107,6 +107,11 @@ hold additional secondary meetings later in the month.
 | Benjie Gillam    | @benjie       | Graphile           | Chandler's Ford, UK   |
 | Andreas Hubel    | @saerdnaer    | Independent        | Munich, DE            |
 | Martin Bonnin    | @martinbonnin | Apollo             | Paris, FR             |
+| Itamar Kestenbaum| @itamark      | Meta               | Plainsboro, NJ        |
+| Ryan Holdren     | @RyanHoldren  | Meta               | Vancouver, CA         |
+| Tianyu Yao       | @tyao1        | Meta               | Foser City, CA        |
+| Jordan Eldredge  | @captbaritone | Meta               | Alameda, CA           |
+| Monica Tang      | @monicatang   | Meta               | San Francisco, CA     |
 
 ## Agenda
 
@@ -129,3 +134,5 @@ hold additional secondary meetings later in the month.
    - [RFC](https://github.com/graphql/graphql-spec/pull/1039)
 1. Full Schemas (20m, Martin)
    - [RFC](https://github.com/graphql/graphql-wg/pull/1375)
+1. Relay Error Handling (20m, Itamar)
+   - [Intro Post](https://github.com/facebook/relay/issues/4416)


### PR DESCRIPTION
We would like to present our progress on Relay Error Handling to the GraphQL WG - both for awareness, and so that other proposals (like Client-Controlled Nullability) are able to keep in sync with ours.