### PR TITLE
Glossary: add source schemas and full schemas

### DIFF
--- a/rfcs/glossary/Appendix C -- Glossary.md
+++ b/rfcs/glossary/Appendix C -- Glossary.md
@@ -116,6 +116,25 @@ Example:
 > Documents are only executable by a GraphQL service if they are
 > {ExecutableDocument} and contain at least one {OperationDefinition}.
 
+### Source schema document
+
+**Definition**: the textual representation (using GraphQL query language) of the
+type system definitions or extensions to be used by a GraphQL service, excluding
+the built-in definitions provided by the service.
+
+Note: The source schema document is generally manually written and passed as
+input to a GraphQL service implementation.
+
+### Full schema document
+
+**Definition**: the textual representation (using GraphQL query language) of the
+type system definitions supported by a GraphQL service, including the built-in
+definitions provided by the service.
+Full schema documents allow validation of any executable document.
+
+Note: The full schema document is generally machine written and produced as an
+output of a GraphQL service implementation.
+
 ### (GraphQL) variables
 
 **Definition**: placeholder for a value within an operation that may be


### PR DESCRIPTION
Introduce terminology for the 2 flavours of schemas:
* **Source schemas** are manually written and given as input to a GraphQL implementation
* **Full schemas** are machine generated and the output of a GraphQL implementation

Not sure whether the Glossary should precede the spec edits or vice/versa. At some point, we'll need new root rules in the grammar for the new terms (like there is ExecutableDocument already). Glossary felt a bit more relaxed and a better place for a discussion but happy to move it to the spec. 

See https://github.com/graphql/graphql-wg/blob/main/rfcs/FullSchemas.md
