### PR TITLE
Update WG statuses, times, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ The GraphQL WG has subcomittees who focus on the development of specific
 projects beyond the GraphQL Spec. These subcomittees make progress within their
 own meetings and report back progress and decisions to GraphQL WG meetings.
 
-<!-- prettier-ignore -->
-| Subcommittee     | Time                          | Host                                               | Agenda Repo                                                                                       |
-| ---------------- | ----------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| GraphiQL         | 2nd Tue, 9:00am - 11:00am PT  | [Tim Suchanek](https://github.com/timsuchanek)     | [graphql/graphiql/working-group](https://github.com/graphql/graphiql/tree/main/working-group)     |
-| GraphQL.js       | 4th Wed, 10:00am - 11:00am PT | [Ivan Goncharov](https://github.com/IvanGoncharov) | [graphql/graphql-js-wg](https://github.com/graphql/graphql-js-wg)                                 |
-| Incremental Delivery | Most Mondays, 7:00am - 8:00am PT | [Rob Richard](https://github.com/robrichard)    | [robrichard/defer-stream-wg](https://github.com/robrichard/defer-stream-wg)
-| Nullability | 4th Wed, 12:00pm - 1:00pm PT | [Stephen Spalding](https://github.com/fotoetienne) | [graphql/nullability-wg](https://github.com/graphql/nullability-wg) |
+| Subcommittee         | Time                           | Host                                               | Agenda Repo                                                                                                     |
+| -------------------- | ------------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| GraphiQL             | 2nd Tue, 9:00am - 11:00am PT   | [Tim Suchanek](https://github.com/timsuchanek)     | [graphql/graphiql/working-group](https://github.com/graphql/graphiql/tree/main/working-group)                   |
+| GraphQL-over-HTTP    | 4th Thu, 17:30 - 18:30 UTC     | [Benjie Gillam](https://github.com/benjie)         | [graphql/graphql-over-http/working-group](https://github.com/graphql/graphql-over-http/tree/main/working-group) |
+| Incremental Delivery | 2nd Mon, 10:00am - 11:00am EST | [Rob Richard](https://github.com/robrichard)       | [robrichard/defer-stream-wg](https://github.com/robrichard/defer-stream-wg)                                     |
+| Nullability          | 4th Wed, 19:00 - 20:00 UTC     | [Stephen Spalding](https://github.com/fotoetienne) | [graphql/client-controlled-nullability-wg](https://github.com/graphql/client-controlled-nullability-wg)         |
+| Composite Schema     | 2nd Thu, 16:00am - 17:00am UTC | [Benjie Gillam](https://github.com/benjie)         | [graphql/composite-schemas-wg](https://github.com/graphql/composite-schemas-wg)                                 |
 
 #### Subcommittees on hiatus
 
@@ -72,10 +72,9 @@ topics. Should you have a topic to discuss that applies to a subcommittee that
 is on hiatus, please raise an issue in the WG repository and mention the host.
 
 <!-- prettier-ignore -->
-| Subcommittee     | Time                          | Host                                               | Agenda Repo                                                                                       |
-| ---------------- | ----------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Composite Schema | 2nd Thu, 8:00am - 10:00am PT  | [Benjie Gillam](https://github.com/benjie)         | [graphql/composite-schemas-wg](https://github.com/graphql/composite-schemas-wg)                   |
-| GraphQL-over-HTTP | 3rd Thu, 8:00am - 10:00am PT  | [Benjie Gillam](https://github.com/benjie)         | [graphql/graphql-over-http/working-group](https://github.com/graphql/graphql-over-http/tree/main/working-group) |
+| Subcommittee         | Time                           | Host                                               | Agenda Repo                                                                                                     |
+| -------------------- | ------------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| GraphQL.js           | 4th Wed, 10:00am - 11:00am PT  | [Ivan Goncharov](https://github.com/IvanGoncharov) | [graphql/graphql-js-wg](https://github.com/graphql/graphql-js-wg)                                               |
 
 ### Joining a meeting?
 


### PR DESCRIPTION
- GraphQL-over-HTTP WG is no longer on hiatus.
- Composite Schemas WG has a new meeting schedule for January, is no longer on hiatus.
- GraphQL.js WG doesn't seem to have had [any meetings](https://www.youtube.com/watch?v=iJWEsVcoNOk&list=PLP1igyLx8foHghwopNuQM7weyP5jR147I) or [any agendas since 2022](https://github.com/graphql/graphql-js-wg/tree/main/agendas), seems to be on hiatus (is that right @IvanGoncharov?)
- Working groups whose times in the agenda file (the source of truth) are expressed in other timezones (PT, EST, UTC) have been updated in this table
- Incremental delivery now meets only once a month