### PR TITLE
Update to latest wgutils

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "devDependencies": {
     "prettier": "^2.1.2",
-    "wgutils": "^0.1.2"
+    "wgutils": "^0.1.5"
   },
   "prettier": {
     "proseWrap": "always"

--- a/wg.config.js
+++ b/wg.config.js
@@ -31,6 +31,12 @@ meeting in which anyone in the GraphQL community may attend.
 This is the primary monthly meeting, which typically meets on the first Thursday
 of the month. In the case we have additional agenda items or follow ups, we also
 hold additional secondary meetings later in the month.`,
+  agendaTemplateBottom: `\
+1. Review previous meeting's action items (5m, Host)
+   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
+   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
+`,
   links: {
     "graphql specification": "https://github.com/graphql/graphql-spec",
     calendar:

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-wgutils@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/wgutils/-/wgutils-0.1.2.tgz#4ec3f74d71ad4c83f4081e710aae48da800f2f9d"
-  integrity sha512-9FaV9TaQr+3YGg3zN6bq6YdNaj2FRO5O14/htAIF0Z5HlVnMYSGAB3Es6nwNrVcPxRMUUo2vlPxDeLAxY5wysg==
+wgutils@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/wgutils/-/wgutils-0.1.5.tgz#fc5815c9ae2bfa9bff633eadb9e0408cd281b151"
+  integrity sha512-Mea/OcK1hAbeEA90vVxZTiqh8NCcQp+dmGl0FVslwS06RHzxig4PZVoLQTIt1Q/jeyMmqZANc2Ud6B0peNXKxA==
   dependencies:
     date-fns "^2"
     date-fns-tz "^2.0.0"


### PR DESCRIPTION
To make wgutils work for more WGs, the end of the agenda needs to be more flexible and the project link doesn't make sense for most. I've removed it from `wgutils` and manually re-added it here.