### PR TITLE
Remove Martin and error paths from Feb wg

### DIFF
--- a/agendas/2024/02-Feb/01-wg-primary.md
+++ b/agendas/2024/02-Feb/01-wg-primary.md
@@ -103,7 +103,6 @@ hold additional secondary meetings later in the month.
 | Name             | GitHub        | Organization       | Location              |
 | :--------------- | :------------ | :----------------- | :-------------------- |
 | Lee Byron (Host) | @leebyron     | GraphQL Foundation | San Francisco, CA, US |
-| Martin Bonnin    | @martinbonnin | Apollo             | Paris, FR             |
 | Jovi De Croock   | @jovidecroock | Stellate           | Aalst, BE             |
 
 ## Agenda
@@ -123,8 +122,6 @@ hold additional secondary meetings later in the month.
    - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
    - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
    - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
-1. Using MUST for error paths  (5m, Martin)
-   - https://github.com/graphql/graphql-spec/pull/1073
 1. New version for fragment-arguments (1m, Jovi)
    - https://github.com/graphql/graphql-spec/pull/1010
    - https://github.com/graphql/graphql-js/pull/4015


### PR DESCRIPTION
Apologies, I have a conflict and sadly won't be able to make it on Thursday. Feel free to keep the "error paths" topic or I'll add it to an upcoming meeting.