### PR TITLE
Extend duration of fragment-arguments topic

### DIFF
--- a/agendas/2024/02-Feb/01-wg-primary.md
+++ b/agendas/2024/02-Feb/01-wg-primary.md
@@ -126,7 +126,7 @@ hold additional secondary meetings later in the month.
    - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
    - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
    - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
-1. New version for fragment-arguments (1m, Jovi)
+1. New version for fragment-arguments (5m, Jovi)
    - https://github.com/graphql/graphql-spec/pull/1010
    - https://github.com/graphql/graphql-js/pull/4015
 1. Using MUST for error paths  (5m, Benoit)


### PR DESCRIPTION
As I have slightly advanced in the execution topic I'd like to extend the duration of discussion if it's possible