### PR TITLE
Add request 'extensions' property to spec

### DIFF
--- a/agendas/2024/03-Mar/07-wg-primary.md
+++ b/agendas/2024/03-Mar/07-wg-primary.md
@@ -143,3 +143,6 @@ hold additional secondary meetings later in the month.
    - [#1032](https://github.com/graphql/graphql-spec/pull/1032) - define "selection set" (already has 2 TSC approvals)
    - [#894](https://github.com/graphql/graphql-spec/pull/894) - clarify "before execution starts" still includes the "request error"s that can be raised in `ExecuteRequest()` (variable coercion failure; not exactly one subscription field assertion failure)
    - [#1069](https://github.com/graphql/graphql-spec/pull/1069) - enforce consistent punctuation in the spec (with CI check)
+1. Add 'extensions' to request (5m, Benjie)
+   - [RFC](https://github.com/graphql/graphql-spec/pull/976)
+   - Aim: advance to RFC1, or reject to RFCX.


### PR DESCRIPTION
Previously discussed: https://github.com/graphql/graphql-wg/blob/623a7bc464406509e0cf41c847e4e4322d577764/notes/2022/2022-09-01.md?plain=1#L102

Conclusion:

> Lee: Benjie seems like you have two options: 1) extension may exist, be aware
  of it 2) improve section and do a better job of defininging the input to an
  execution.

I'm proposing that we go with option 1: it might exist, if it is present it must be a map (object), it is not otherwise specified.