### PR TITLE
Change "agenda item" topic to just "ready for review" items

### DIFF
--- a/agendas/2024/12-Dec/05-wg-primary.md
+++ b/agendas/2024/12-Dec/05-wg-primary.md
@@ -117,7 +117,4 @@ hold additional secondary meetings later in the month.
 1. Introduction of attendees (5m, Host)
 1. Determine volunteers for note taking (1m, Host)
 1. Review agenda (2m, Host)
-1. Review previous meeting's action items (5m, Host)
-   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
-   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
-   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
+1. Check for [ready for review agenda items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc) (5m, Host)

--- a/agendas/2025/01-Jan/02-wg-primary.md
+++ b/agendas/2025/01-Jan/02-wg-primary.md
@@ -117,7 +117,4 @@ hold additional secondary meetings later in the month.
 1. Introduction of attendees (5m, Host)
 1. Determine volunteers for note taking (1m, Host)
 1. Review agenda (2m, Host)
-1. Review previous meeting's action items (5m, Host)
-   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
-   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
-   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
+1. Check for [ready for review agenda items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc) (5m, Host)

--- a/agendas/2025/02-Feb/06-wg-primary.md
+++ b/agendas/2025/02-Feb/06-wg-primary.md
@@ -117,7 +117,4 @@ hold additional secondary meetings later in the month.
 1. Introduction of attendees (5m, Host)
 1. Determine volunteers for note taking (1m, Host)
 1. Review agenda (2m, Host)
-1. Review previous meeting's action items (5m, Host)
-   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
-   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
-   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
+1. Check for [ready for review agenda items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc) (5m, Host)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "devDependencies": {
     "prettier": "^2.1.2",
-    "wgutils": "^0.1.5"
+    "wgutils": "^1.0.0"
   },
   "prettier": {
     "proseWrap": "always"

--- a/wg.config.js
+++ b/wg.config.js
@@ -31,12 +31,6 @@ meeting in which anyone in the GraphQL community may attend.
 This is the primary monthly meeting, which typically meets on the first Thursday
 of the month. In the case we have additional agenda items or follow ups, we also
 hold additional secondary meetings later in the month.`,
-  agendaTemplateBottom: `\
-1. Review previous meeting's action items (5m, Host)
-   - [Ready for review](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
-   - [All open action items (by last update)](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
-   - [All open action items (by meeting)](https://github.com/graphql/graphql-wg/projects?query=is%3Aopen+sort%3Aname-asc)
-`,
   links: {
     "graphql specification": "https://github.com/graphql/graphql-spec",
     calendar:

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-wgutils@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/wgutils/-/wgutils-0.1.5.tgz#fc5815c9ae2bfa9bff633eadb9e0408cd281b151"
-  integrity sha512-Mea/OcK1hAbeEA90vVxZTiqh8NCcQp+dmGl0FVslwS06RHzxig4PZVoLQTIt1Q/jeyMmqZANc2Ud6B0peNXKxA==
+wgutils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wgutils/-/wgutils-1.0.0.tgz#7f80c8ec7a9da56a0aa9c1a1a1b1911cd440fc25"
+  integrity sha512-XYgCT+g9Exrja3iWdnptyrh1KAFnG1ZKnHnpg5oFqnbXqIQriCJp+vME38S8ieHZVx4nxUjCKHexF5gAD2b0dg==
   dependencies:
     date-fns "^2"
     date-fns-tz "^2.0.0"


### PR DESCRIPTION
Slightly different to [what was proposed in the 2024-11 primary WG](https://www.youtube.com/watch?v=dgT8GhGDx_E&list=PLP1igyLx8foH30_sDnEZnxV_8pYW3SDtb&t=496s) - rather than removing action items from the agenda entirely, I've updated to just review the "ready for review" items. Action items can still be used to manage tasks, but will not be reviewed in the meeting unless labelled for review (please request on the relevant action item and the label can be added).