### PR TITLE
Add annual agenda items for TSC elections

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "devDependencies": {
     "prettier": "^2.1.2",
-    "wgutils": "^1.0.0"
+    "wgutils": "^1.1.0"
   },
   "prettier": {
     "proseWrap": "always"

--- a/wg.config.js
+++ b/wg.config.js
@@ -40,6 +40,28 @@ hold additional secondary meetings later in the month.`,
     "ical file":
       "https://calendar.google.com/calendar/ical/linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8%40group.calendar.google.com/public/basic.ics",
   },
+
+  annualItems: [
+    {
+      month: 11,
+      allMeetings: true,
+      text: `**TSC elections**: open for self-nominations (5m, Host)
+- [Election process](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#election-process)
+- [Nomination form](https://tsc-nomination.graphql.org/)`,
+    },
+    {
+      month: 12,
+      text: `**TSC elections**: voting now open (2m, Host)
+- [Election process](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#election-process)`,
+    },
+    {
+      month: 1,
+      text: `**TSC**: election results (2m, Host)
+- [Election process](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#election-process)
+- [This year's TSC members](https://github.com/graphql/graphql-wg/blob/main/GraphQL-TSC.md#tsc-members)`,
+    },
+  ],
+
   secondaryMeetings: [
     // We decided at the primary WG in November 2024 to cancel the secondaries
     // since they have not been leveraged for a while. We can bring them back

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-wgutils@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wgutils/-/wgutils-1.0.0.tgz#7f80c8ec7a9da56a0aa9c1a1a1b1911cd440fc25"
-  integrity sha512-XYgCT+g9Exrja3iWdnptyrh1KAFnG1ZKnHnpg5oFqnbXqIQriCJp+vME38S8ieHZVx4nxUjCKHexF5gAD2b0dg==
+wgutils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/wgutils/-/wgutils-1.1.0.tgz#bd73f43f1c1b13109a797c9e19227c6f38a6b8fd"
+  integrity sha512-E5ce8Sfeu/X7abXIVhw4Q5SqMyWjtpoGSEzqLfYxGZKNCJ0z8T9htjtY+4Y+/DyE2Ui4JvHOrfcN6RCoB3KkMg==
   dependencies:
     date-fns "^2"
     date-fns-tz "^2.0.0"


### PR DESCRIPTION
`wgutils` now supports `annualItems`. I've added some items to help us adhere to the TSC election process. We could also add items to remind us to cut spec releases/etc if we wanted to do that on a schedule.

@leebyron the form at https://tsc-nomination.graphql.org/ needs updating each year (including now!) - or make it evergreen?

