### PR TITLE
Enable agenda automerge workflow

### DIFF
--- a/.github/workflows/wgutils-automerge.yml
+++ b/.github/workflows/wgutils-automerge.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   validate-and-merge:
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/wgutils-automerge.yml
+++ b/.github/workflows/wgutils-automerge.yml
@@ -1,0 +1,49 @@
+name: Agenda auto-merge
+
+on:
+  pull_request_target:
+    types: [synchronize, opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: read
+  checks: read
+
+jobs:
+  validate-and-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      # SECURITY: it's critical we do not check out the source pull request!
+      - name: Checkout the main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      # We need wgutils to be installed
+      - run: yarn install
+
+      - name: Wait for checks to pass
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Give 15 seconds for any checks to register
+          sleep 15
+
+          # Wait for checks to pass
+          CHECKS_OUTPUT="$(gh pr checks ${{ github.event.pull_request.number }} --fail-fast --watch --required --json bucket --jq '.state' 2>&1 || true)"
+
+          if [[ "$CHECKS_OUTPUT" == "pass" ]]; then
+            echo "$CHECKS_OUTPUT"
+          else
+            echo "PR state failed? $CHECKS_OUTPUT"
+            exit 1
+          fi
+
+      - name: Automerge if wgutils approves
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if yarn wgutils can-automerge "${{ github.event.pull_request.number }}" "${{ github.event.pull_request.head.sha }}"; then
+            gh pr merge "${{ github.event.pull_request.number }}" --squash --auto --match-head-commit "${{ github.event.pull_request.head.sha }}"
+          fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "devDependencies": {
     "prettier": "^2.1.2",
-    "wgutils": "^1.1.0"
+    "wgutils": "^1.2.0-beta.0"
   },
   "prettier": {
     "proseWrap": "always"

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,11 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+parse-diff@0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/parse-diff/-/parse-diff-0.11.1.tgz#d93ca2d225abed280782bccb1476711ca9dd84f0"
+  integrity sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA==
+
 prettier@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
@@ -105,13 +110,14 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-wgutils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/wgutils/-/wgutils-1.1.0.tgz#bd73f43f1c1b13109a797c9e19227c6f38a6b8fd"
-  integrity sha512-E5ce8Sfeu/X7abXIVhw4Q5SqMyWjtpoGSEzqLfYxGZKNCJ0z8T9htjtY+4Y+/DyE2Ui4JvHOrfcN6RCoB3KkMg==
+wgutils@^1.2.0-beta.0:
+  version "1.2.0-beta.0"
+  resolved "https://registry.yarnpkg.com/wgutils/-/wgutils-1.2.0-beta.0.tgz#9742d2ee433c7c521bd17b0fea905741f790461a"
+  integrity sha512-N09sJXrl6QOqTsMkS5PbyJPi0HTj3weY0XoFO6ULljGNB4QSCQURFDTHMMSi2Syezsb5UatPUAP4Ng03Ow3x+w==
   dependencies:
     date-fns "^2"
     date-fns-tz "^2.0.0"
+    parse-diff "0.11.1"
     yargs "^17.7.2"
     zod "^3.22.4"
 


### PR DESCRIPTION
See also:

https://github.com/graphql/wgutils/commit/7280d940f1d300605b9e73b2db6e0588274830cc

Essentially this checks the following:

- Required CI checks (i.e. CLAbot) have passed
- The PR only modifies 1 file
- The file is an agenda file
- The PR only adds lines to the file (no deletions)
- The text of the lines added look like they're reasonable characters

Assuming all this passes, it then merges the PR automatically.

Careful attention has been paid to this article series: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

In particular we do not pull down the changes from the other branch, we instead review the patch to make sure it's safe. We also guard against timing attacks (I think!) by checking the diff hash matches, and only merging when the PR hash matches.

I believe that the `github.token` is limited to the repository, so the scope of this going wrong is, I think, limited. I (and probably others) have backups of the git history on our machines, so I'd like to think the worst that could happen in the event of a vulnerability is the deletion of issues/PRs/etc (which would be bad, but not devastating) and potentially the leaking of any organization global secrets stored in GitHub, which currently is just the codecov token so should not be a huge concern.

Expect some iteration.