### PR TITLE
! meaning compatability updated

### DIFF
--- a/rfcs/SemanticNullability.md
+++ b/rfcs/SemanticNullability.md
@@ -250,7 +250,7 @@ and that `!` means non-nullable. Our changes should not invalidate this content.
 
 | [1][solution-1] | [2][solution-2] | [3][solution-3] | [4][solution-4] | [5][solution-5] |
 |-----------------|-----------------|-----------------|-----------------|-----------------|
-| ✅               | 🚫              | ✅               | 🚫              | ✅               |
+| ✅               | 🚫              | 🚫               | 🚫              | ✅               |
 
 Criteria score: 🥈
 
@@ -497,7 +497,7 @@ day-to-day work.
     input and output (the difference between semantic an strict non-null does
     not occur on input)
 - [F][criteria-f]
-  - ✅ `Int` reatains its meaning across both modes, and `Int!` means
+  - 🚫 `Int` reatains its meaning across both modes, and `Int!` means
     non-nullable in both modes. Only the SDL ever uses `Int!!` and it still
     means non-null, just with the additional "kills parent on exception"
     behavior.

--- a/rfcs/SemanticNullability.md
+++ b/rfcs/SemanticNullability.md
@@ -497,10 +497,10 @@ day-to-day work.
     input and output (the difference between semantic an strict non-null does
     not occur on input)
 - [F][criteria-f]
-  - 🚫 `Int` reatains its meaning across both modes, and `Int!` means
-    non-nullable in both modes. Only the SDL ever uses `Int!!` and it still
-    means non-null, just with the additional "kills parent on exception"
-    behavior.
+  - 🚫 `Int` reatains its meaning across both modes, but `Int!` means
+    non-nullable in one mode, but semantic non-nullable in another. Only
+    the SDL ever uses `Int!!` and it still means non-null, just with the
+    additional "kills parent on exception" behavior.
 - [G][criteria-g]
   - ✅ Error capture positions unchanged when error propagation enabled
 - [H][criteria-h]


### PR DESCRIPTION
In option 3, the meaning and mechanics of a `!` adorned type change when a document adopts semantic nullability