### PR TITLE
SemanticNullability -> SemanticNullabilityType; add precision

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 agendas/*/*.md
 agendas/*/*/*.md
-rfcs/SemanticNullability.md
+rfcs/SemanticNullabilityType.md

--- a/rfcs/SemanticNullabilityType.md
+++ b/rfcs/SemanticNullabilityType.md
@@ -1,4 +1,4 @@
-# RFC: Semantic Nullability
+# RFC: Semantic Nullability Type
 
 # 📜 Problem History
 
@@ -166,8 +166,13 @@ non-null" type.
 
 # 📜 Problem Statement
 
-GraphQL needs to be able to represent semantically nullable and semantically
-non-nullable types as such when error propagation is disabled.
+GraphQL schema authors need a way to explicitly distinguish between
+**semantically nullable** (where `null` is a meaningful application-level
+value), **semantically non-nullable** (where `null` should not be expected but
+might still occur due to errors), and **strictly non-nullable** (where `null`
+must never appear, even in the presence of errors). This distinction ensures
+that schemas accurately convey application intent while defining appropriate
+error boundaries when error propagation is enabled.
 
 # 📋 Solution Criteria
 


### PR DESCRIPTION
Following discussion with @martinbonnin it became obvious that the title of this RFC was too broad and seemed to make it such that any proposal to disable null bubbling would solve the problem; however as outlined in the problem history the intent of this RFC is that schemas gain a new type to enable splitting the existing "nullable" into "semantically nullable" and "semantically non-nullable". I've renamed the RFC to include the word "type" and have added precision to the problem statement so that it better outlines the problem it is attempting to solve and is a better summary of the problem history section above it.

With this change, I think we should explicitly indicate that solution 5 is a counter-proposal - it's an argument against the need for a new explicit semantic nullability type.

cc @martinbonnin @twof 