### PR TITLE
Add "cut a new spec release" to next WG

### DIFF
--- a/agendas/2025/03-Mar/06-wg-primary.md
+++ b/agendas/2025/03-Mar/06-wg-primary.md
@@ -107,6 +107,7 @@ hold additional secondary meetings later in the month.
 | Lee Byron (Host) | @leebyron     | GraphQL Foundation | San Francisco, CA, US |
 | Alex Reilly  | @twof     | DoorDash | San Francisco, CA, US |
 | Jovi De Croock | @jovidecroock     | Independent | Aalst, BE |
+| Benjie Gillam    | @benjie       | Graphile           | Chandler's Ford, UK   | 
 
 ## Agenda
 
@@ -119,8 +120,9 @@ hold additional secondary meetings later in the month.
 1. Determine volunteers for note taking (1m, Host)
 1. Review agenda (2m, Host)
 1. Check for [ready for review agenda items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc) (5m, Host)
-1. Nullability Working Group status update (Alex Reilly, 15m)
-1. Fragment-Arguments (Jovi De Croock, 10m)
+1. Nullability Working Group status update (15m, Alex Reilly)
+1. Fragment-Arguments (10m, Jovi De Croock)
    - Spec has been finished for a bit
    - Implementation is under an experimental flag in GraphQL v17
    - Advance to stage 2
+1. Let's cut a spec release... it's been 3+ years! (15m, Benjie)


### PR DESCRIPTION
We've had formatting, minor editorial (including definitions), and typo fixes, but also:

- graphql/graphql-spec#916
- graphql/graphql-spec#849
- graphql/graphql-spec#805
- graphql/graphql-spec#958
- graphql/graphql-spec#963
- graphql/graphql-spec#964
- graphql/graphql-spec#965
- graphql/graphql-spec#966
- graphql/graphql-spec#977
- graphql/graphql-spec#974
- graphql/graphql-spec#975
- graphql/graphql-spec#979
- graphql/graphql-spec#891
- graphql/graphql-spec#987
- graphql/graphql-spec#1009
- graphql/graphql-spec#1025
- graphql/graphql-spec#1042
- graphql/graphql-spec#1016
- graphql/graphql-spec#1086
- graphql/graphql-spec#1073
- graphql/graphql-spec#1032
- graphql/graphql-spec#1090
- graphql/graphql-spec#994
- graphql/graphql-spec#1066
- graphql/graphql-spec#1057
- graphql/graphql-spec#1040
- graphql/graphql-spec#1099
- graphql/graphql-spec#1130
- graphql/graphql-spec#1123
- graphql/graphql-spec#1129

We've got some really big topics coming up, including fragment arguments, nullability, and incremental delivery; let's get the above list of features out as the latest stable version of the GraphQL spec so that these new major topics can start from a (relatively) clean slate.

I think we should aim to cut a new spec release roughly every 18 months, and we're long overdue (at 40 months).