### PR TITLE
Add objection: lower the score of `The solution should add value even with error propagation enabled` 

### DIFF
--- a/rfcs/SemanticNullability.md
+++ b/rfcs/SemanticNullability.md
@@ -415,11 +415,15 @@ that's only nullable because errors may occur. GraphQL-TOE can be used in such
 situations so that codegen can safely use non-nullable types in semantically
 non-nullable positions.
 
+
 | [1][solution-1] | [2][solution-2] | [3][solution-3] | [4][solution-4] | [5][solution-5] |
 |-----------------|-----------------|-----------------|-----------------|-----------------|
 | ✅               | ✅              | ✅               | ✅               | 🚫               |
 
 Criteria score: 🥇
+
+* ✂️ Objection: proposal to lower the score to 🥉. Do we have any evidence that some teams need this?
+
 
 ## 🎯 O. Should not have breaking changes for existing executable documents
 


### PR DESCRIPTION
Feels like this is outside the "semantic nullability" problem. 

The problem of indicating whether or not a position can error in the schema is a separate, larger problem IMO that could require larger changes like adding even more types to the type system:

```rust 
String
Option<String>
Result<String, Error>
Result<Option<String>, Error> 
```

This is a much wider question though and I suggest we leave it out for now.