### PR TITLE
Add notes taken in the meeting

### DIFF
--- a/notes/2025/2025-03.md
+++ b/notes/2025/2025-03.md
@@ -1,0 +1,31 @@
+# GraphQL WG Notes - March 2025
+
+**Watch the replays:**
+[GraphQL Working Group Meetings on YouTube](https://www.youtube.com/playlist?list=PLP1igyLx8foH30_sDnEZnxV_8pYW3SDtb)
+
+Agenda:
+https://github.com/graphql/graphql-wg/blob/main/agendas/2025/03-Mar/06-wg-primary.md
+
+## GraphQL Conf WG sessions
+
+- We want to make GraphQL Conf about community
+- Proposal
+  [https://gist.github.com/benjie/0ca0fd87cee41783d8fd19d659c9ca0a](https://gist.github.com/benjie/0ca0fd87cee41783d8fd19d659c9ca0a)
+- Please reach out to Lee or Benjie if you have any ideas
+
+## Non nullable includeDeprecated argument
+
+- RFC1 => Martin to make graphql-js PR and add it to next month agenda.
+
+## Open Telemetry
+
+-
+
+## Nullability
+
+- Alex: aim is to reach consensus by the next wg.
+- Lee: OK to let solution 2. go.
+- Alex: solution 3. and 4. Would create a kind of dialect.
+- Alex: need a document directive.
+- Alex: we also need to disable null bubbling.
+- Alex: breaking changes are fuzzy,


### PR DESCRIPTION
We didn't do a great job on notes this time. I'd like to look into having AI generate the notes based on the subtitles Zoom captures (which, hopefully, will identify the speaker), but I've not had time to set that up yet. I'll talk with the operations team at GraphQL and see if we can get Zoom's AI notes enabled for our public WGs, maybe.