### PR TITLE
Remove redundant links

### DIFF
--- a/agendas/2025/04-Apr/03-wg-primary.md
+++ b/agendas/2025/04-Apr/03-wg-primary.md
@@ -167,8 +167,6 @@ hold additional secondary meetings later in the month.
      - Solution 2-5: have been rejected by their respective champions
      - Nullability WG reached consensus on solution 1 (solution 6 is already implemented in a number of places, and is easy to migrate to solution 1).
      - New contender: [Solution 7](https://github.com/graphql/graphql-wg/discussions/1700)
-     - Spec edits: [Allow clients to disable error propagation via request parameter](https://github.com/graphql/graphql-spec/pull/1153)
-     - graphql-js implementation: [Implement onError proposal](https://github.com/graphql/graphql-js/pull/4364)
      - Spec edits: [SemanticNonNull type](https://github.com/graphql/graphql-spec/pull/1065)
      - graphql-js implementation: [Experimental support for semantic-non-null](https://github.com/graphql/graphql-js/pull/4192)
 1. Please give feedback on the following (2m, Martin)


### PR DESCRIPTION
Didn't realize they were listed in the specific "disableErrorPropagation" item just above.