### PR TITLE
Add a template RFC

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -16,3 +16,4 @@ That said, please follow these suggestions:
 
 * New proposals should be presented in a [working group meeting](../agendas). Submitting a document here is not sufficient or required to introduce a new proposal.
 * Favor documents which define a problem and explore a solution space rather than propose a specific change. The intent of documents found here are to help ask and answer questions to build confidence and advance an RFC.
+* A template is provided [here](./TEMPLATE.md) as a starting point for new RFCs.

--- a/rfcs/TEMPLATE.md
+++ b/rfcs/TEMPLATE.md
@@ -1,0 +1,45 @@
+<!-- This template is provided as a suggested starting point. You may alter the
+format where necessary. -->
+
+# RFC: <Title>
+
+**Proposed by:** [<Full Name>](https://github.com/<username>) - <Organization>
+
+<!-- Briefly summarize and explainin the concepts introduced by the RFC. Usually
+one or two short sentences or paragraphs. -->
+
+## 📜 Problem Statement
+
+<!-- Briefly explain the problem being solved. Assume no prior knowledge (other
+than the current GraphQL specification) and start from first principles. Usually
+one or two short paragraphs. -->
+
+**Example**
+
+<!-- Provide a minimal code example here if possible. -->
+
+## 💡 Proposed Solution
+
+<!-- Explain the proposal! Be detailed enough to explain the idea and major edge
+cases - but avoid being overly detailed. The primary goal is to communicate the
+idea at a high level. The specification edit PR will cover all the precice
+implementation details. -->
+
+## ⚠️ Risks
+
+<!-- Think: Why *shouldn't* we do this proposal? List any unaddressed risks or
+edge cases we need to consider. -->
+
+## Appendix
+
+<!-- Additional appendix sections are encourged as the editor sees fit. You are
+encouraged to keep the main body of the RFC focused on the chosen solution. -->
+
+### 🎨 Prior Art
+
+<!-- If applicable, list any existing userland solutions that relate to this
+RFC. -->
+
+### 🤔 Alternatives Considered
+
+<!-- If applicable, list any alternate naming or implementations considered. --> 


### PR DESCRIPTION
I feel like something like this is always useful, especially for folks new to writing RFCs.  

(We can bikeshed the contents. Just having *some* starting point feels helpful.)

I might also suggest highlighting an RFC we feel was particularly well written as an example to follow.