### PR TITLE
GraphQL TSC mailing list is private

### DIFF
--- a/GraphQL-TSC.md
+++ b/GraphQL-TSC.md
@@ -166,6 +166,10 @@ If you have questions about these processes, please contact [operations@graphql.
 
 The [graphql-wg](https://github.com/graphql/graphql-wg/) repository hosts issues, discussions, and working files used by the TSC and the rest of the working group.
 
+You may ask the TSC a question by 
+[opening an issue](https://github.com/graphql/graphql-wg/issues/new) and
+mentioning `@graphql/tsc` in your issue description.
+
 ### Discord
 
 GraphQL maintains a [Discord](https://discord.graphql.org) for communication and collaboration, which is open for anyone to join. Once you join [Discord](https://discord.graphql.org), you can participate in any public channels.


### PR DESCRIPTION
The `tsc` mailing list now redirects to tsc-private; the archives are not (and should not be!) public. I don't know if people can actually email it, but I'd advise that we remove it for now.