### PR TITLE
Add martin and "Update description of Fragments" to Jan working group

### DIFF
--- a/agendas/2026/01-Jan/15-wg-primary.md
+++ b/agendas/2026/01-Jan/15-wg-primary.md
@@ -128,5 +128,5 @@ who could not make the primary meeting time.
 1. [RFC, Type composition](https://github.com/graphql/graphql-spec/issues/1197#issuecomment-3581857997) (5m, Bjørn Wiegell)
 1. Reminder: [grants available for key initiatives](https://graphql.org/community/foundation/community-grant/) (1m, Host)
 2. Fragments are not for reuse (2m)
-    - https://services.gradle.org/distributions-snapshots/gradle-9.4.0-20251215022449+0000-bin.zip"
+    - https://github.com/graphql/graphql-spec/pull/1193
     - Aim: merge


### PR DESCRIPTION
Adding "Update description of Fragments" as a reminder for ourselves. Every day we wait is another day user learn outdated practices.

I'm down to merge before the end of the year if that's an option. But if we can't make it, then at least I'm hoping Jan 2026 is the finish line. 

