### PR TITLE
Update agenda attendees

### DIFF
--- a/agendas/2026/07-Jul/02-wg-primary.md
+++ b/agendas/2026/07-Jul/02-wg-primary.md
@@ -107,6 +107,7 @@ hold additional secondary meetings later in the month.
 | Lee Byron (Host) | @leebyron     | GraphQL Foundation | San Francisco, CA, US |
 | Benjie Gillam    | @benjie       | Graphile           | Chandler's Ford, UK   |
 | James Bellenger  | @jbellenger   | Airbnb             | Oakland, CA, US       |
+| Kevin Gorham     | @gmale        | Meta               | Fishers, IN, US       | 
 
 ## Agenda
 


### PR DESCRIPTION
This is a placeholder to trigger CLA approval. Per Matt Mahoney : "try making a PR on graphql-wg: just add yourself to July then if that lands take yourself off"