### PR TITLE
fix: make tools/gen-agenda.js functional

### DIFF
--- a/tools/gen-agenda.js
+++ b/tools/gen-agenda.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-console.error(
-  `\
-Please instead run:
 
-  yarn && yarn gen-agenda ${process.argv.slice(2).join(" ")}
-`
-);
-process.exit(1);
+const { spawnSync } = require('child_process');
+
+const args = process.argv.slice(2);
+
+// Run the wgutils agenda gen command using npx to ensure the binary is found
+spawnSync('npx', ['wgutils', 'agenda', 'gen', ...args], { stdio: 'inherit' });


### PR DESCRIPTION
The tools/gen-agenda.js script was a non-functional placeholder that exited with an error, directing users to run yarn gen-agenda instead. This was confusing and led to a poor developer experience. The script has been updated to use child_process.spawnSync to execute wgutils agenda gen directly, making it a functional wrapper. This allows running the agenda generation script directly with node tools/gen-agenda.js YYYY MM, consistent with the expected utility of the file.