### PR TITLE
Remove deprecated tools

### DIFF
--- a/tools/gen-agenda.js
+++ b/tools/gen-agenda.js
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-console.error(
-  `\
-Please instead run:
-
-  yarn && yarn gen-agenda ${process.argv.slice(2).join(" ")}
-`
-);
-process.exit(1);


### PR DESCRIPTION
`tools/gen-agenda.js` used to generate agendas. We replaced it with wgutils, and left a script in its place to guide people to the new flow. This was a while ago now, everyone should have migrated off of the old script, so it's time to remove both that script and the folder that contains it to tidy up the repo.

- Fixes #2006 
