### PR TITLE
Add agenda item on writing robust applications

### DIFF
--- a/agendas/2026/07-Jul/02-wg-primary.md
+++ b/agendas/2026/07-Jul/02-wg-primary.md
@@ -107,6 +107,7 @@ hold additional secondary meetings later in the month.
 | Lee Byron (Host) | @leebyron     | GraphQL Foundation | San Francisco, CA, US |
 | Benjie Gillam    | @benjie       | Graphile           | Chandler's Ford, UK   |
 | James Bellenger  | @jbellenger   | Airbnb             | Oakland, CA, US       |
+| Martin Bonnin  | @martinbonnin   | Apollo             | Paris, FR       |
 
 ## Agenda
 

--- a/agendas/2026/07-Jul/02-wg-primary.md
+++ b/agendas/2026/07-Jul/02-wg-primary.md
@@ -124,6 +124,9 @@ hold additional secondary meetings later in the month.
 1. Check for [ready for review agenda items](https://github.com/graphql/graphql-wg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc) (5m, Host)
 1. **Spec release**: will freeze release just before next month's meeting; last chance for editorial changes (5m, Host)
 1. Reminder: [grants available for key initiatives](https://graphql.org/community/foundation/community-grant/) (1m, Host)
+1. [Best practice: writing robust applications](https://github.com/graphql/graphql.github.io/pull/2434) (2m, Martin)
+   - Aim: awareness.
+   - No need to spend too much sync time discussing this. Let's do a first async pass.
 1. [Sibling errors should not be added after propagation](https://github.com/graphql/graphql-spec/pull/1184) (5m, Benjie)
    - JS implementation (merged, shipped in v17 as default): https://github.com/graphql/graphql-js/pull/4458
 1. [Allow empty selection


### PR DESCRIPTION
Added a new agenda item on best practices for writing robust applications with an aim for awareness and asynchronous discussion.

@benjie I see we have a packed agenda and wasn't sure we could make it to the end. The goal is literally to spend 2min on this to ask for offline feedback so I took the liberty of adding it before the more technical discussions. Feel free to shuffle as needed.