### PR TITLE
Add clarification for annotation keyword in WG primary

### DIFF
--- a/agendas/2026/09-Sep/03-wg-primary.md
+++ b/agendas/2026/09-Sep/03-wg-primary.md
@@ -139,3 +139,4 @@ hold additional secondary meetings later in the month.
    - https://github.com/graphql/graphql-wg/blob/main/rfcs/Struct.md
    - clarification needed: @oneOf on output (vs input structs aka input unions)
    - clarification needed: implies defaultValue v2 (`__InputValue.defaultValue`) generates a giant oneOf'd object to pick from
+   - clarification needed (for future work): annotation keyword vs directives on directives 


### PR DESCRIPTION
Added clarification needed for annotation keyword vs directives.